### PR TITLE
Add `removeDefaultMessages` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 - **`moduleSourceName`**: The ES6 module source name of the React Intl package. Defaults to: `"react-intl"`, but can be changed to another name/path to React Intl.
 
+- **`removeDefaultMessages`**: Whether `defaultMessage` should be removed from the source after it's extracted to save bytes. Defaults to: `false`.
+
 ### Via Node API
 
 The extract message descriptors are available via the `metadata` property on the object returned from Babel's `transform()` API:

--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -16,6 +16,9 @@ const fixtures = [
     ['moduleSourceName', {
         moduleSourceName: 'react-i18n',
     }],
+    ['removeDefaultMessages', {
+        removeDefaultMessages: true,
+    }],
 ];
 
 fixtures.forEach((fixture) => {

--- a/src/index.js
+++ b/src/index.js
@@ -260,11 +260,13 @@ export default function ({types: t}) {
                         storeMessage(descriptor, path, state);
 
                         // Remove description since it's not used at runtime.
-                        attributes.some((attr) => {
-                            const ketPath = attr.get('name');
-                            if (getMessageDescriptorKey(ketPath) === 'description') {
+                        // Remove defaultMessage if option is set to true.
+                        attributes.forEach((attr) => {
+                            const keyPath = attr.get('name');
+                            const key = getMessageDescriptorKey(keyPath);
+
+                            if (key === 'description' || (opts.removeDefaultMessages && key === 'defaultMessage')) {
                                 attr.remove();
-                                return true;
                             }
                         });
 
@@ -315,10 +317,13 @@ export default function ({types: t}) {
                             t.stringLiteral('id'),
                             t.stringLiteral(descriptor.id)
                         ),
-                        t.objectProperty(
-                            t.stringLiteral('defaultMessage'),
-                            t.stringLiteral(descriptor.defaultMessage)
-                        ),
+                        // Remove defaultMessage if option is set to true.
+                        ...(!state.opts.removeDefaultMessages && [
+                            t.objectProperty(
+                                t.stringLiteral('defaultMessage'),
+                                t.stringLiteral(descriptor.defaultMessage)
+                            ),
+                        ]),
                     ]));
 
                     // Tag the AST node so we don't try to extract it twice.

--- a/test/fixtures/removeDefaultMessages/actual.js
+++ b/test/fixtures/removeDefaultMessages/actual.js
@@ -1,0 +1,20 @@
+import React, {Component} from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
+
+const messages = defineMessages({
+    foo: {
+        id: 'greeting-user',
+        defaultMessage: 'Hello, {name}',
+    },
+});
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <FormattedMessage
+                id='greeting-world'
+                defaultMessage='Hello World!'
+            />
+        );
+    }
+}

--- a/test/fixtures/removeDefaultMessages/expected.js
+++ b/test/fixtures/removeDefaultMessages/expected.js
@@ -1,0 +1,50 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactIntl = require('react-intl');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var messages = (0, _reactIntl.defineMessages)({
+    foo: {
+        'id': 'greeting-user'
+    }
+});
+
+var Foo = function (_Component) {
+    _inherits(Foo, _Component);
+
+    function Foo() {
+        _classCallCheck(this, Foo);
+
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    }
+
+    _createClass(Foo, [{
+        key: 'render',
+        value: function render() {
+            return _react2.default.createElement(_reactIntl.FormattedMessage, {
+                id: 'greeting-world'
+            });
+        }
+    }]);
+
+    return Foo;
+}(_react.Component);
+
+exports.default = Foo;

--- a/test/fixtures/removeDefaultMessages/expected.json
+++ b/test/fixtures/removeDefaultMessages/expected.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "greeting-user",
+    "defaultMessage": "Hello, {name}"
+  },
+  {
+    "id": "greeting-world",
+    "defaultMessage": "Hello World!"
+  }
+]

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ const skipTests = [
     'moduleSourceName',
     'icuSyntax',
     'removeDescriptions',
+    'removeDefaultMessages'
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -89,6 +90,30 @@ describe('options', () => {
             console.error(e);
             assert(false);
         }
+    });
+
+    it('removes defaultMessages when removeDefaultMessages=true', () => {
+        const fixtureDir = path.join(fixturesDir, 'removeDefaultMessages');
+
+        let actual;
+        try {
+            actual = transform(path.join(fixtureDir, 'actual.js'), {
+                removeDefaultMessages: true,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+
+        // Check code output
+        const expected = fs.readFileSync(path.join(fixtureDir, 'expected.js'));
+        assert.equal(trim(actual), trim(expected));
+
+        // Check message output
+        const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
+        assert.equal(trim(actualMessages), trim(expectedMessages));
     });
 
     it('respects moduleSourceName', () => {


### PR DESCRIPTION
The problem we are having is that we could reduce our JS bundle by almost 100kb by removing the `defaultMessages`. We do not use them, because we have our own fallback to EN in place. As I understand, removing them from our own source code will not work with this plugin. Also, it would be nice to keep them in our source code for development.

So I have added an option that does this. It would be nice if it could be added to this plugin and please let me know if you don't agree with the way I've implemented it.