### PR TITLE
Fix root when the user uses symlinks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,10 +194,19 @@ export default function ({types: t}) {
             if (opts.messagesDir && descriptors.length > 0) {
                 // Make sure the relative path is "absolute" before
                 // joining it with the `messagesDir`.
-                const relativePath = p.join(
+                let relativePath = p.join(
                     p.sep,
                     p.relative(process.cwd(), filename)
                 );
+                // Solve when the window user has symlink on the directory, because
+                // process.cwd on windows returns the symlink root,
+                // and filename (from babel) returns the original root
+                if(process.platform === 'win32'){
+                    const { name } = p.parse(process.cwd());
+                    if(relativePath.includes(name)){
+                        relativePath = relativePath.slice(relativePath.indexOf(name) + name.length);
+                    }
+                }
 
                 const messagesFilename = p.join(
                     opts.messagesDir,


### PR DESCRIPTION
## Context
- One folder called 'project'
- A symlink from 'project' called 'symproject'.
- A file from babel `/files/file.js`

## Problem
On Linux
- executed from /project -> `process.cwd` returns /project
- executed from /symproject -> `process.cwd` returns /project

On Windows
- executed from C:/project -> `process.cwd` returns C:/project
- executed from C:/symproject -> `process.cwd` returns C:/symproject

So the problem only occurs on `Windows`, because the files coming from babel has the `original` path (`C:/project/files/file.js`).
```javascript
  // process.cwd() = C:/symproject
  // filename = C:/project/files/file.js
  p.relative(process.cwd(), filename)
  //output = C:/project/files/file.js
```
Then use `join` getting as result `/C:/project/files/file.js` making impossible to mkdirp to create folder with that name.

### Solution
Its difficult to determine if we are on a symlink or not. So, just parse `process.cwd` and get `name` property, it contains the last folder from the path. Then slice all the content before that path on `relativePath`