### PR TITLE
Added support for single-file JSON / XLIFF 1.2 outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,16 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 #### Options
 
-- **`messagesDir`**: The target location where the plugin will output a `.json` file corresponding to each component from which React Intl messages were extracted. If not provided, the extracted message descriptors will only be accessible via Babel's API.
+- **`format`**:
+  - **`json-multi-file`** (default): will output a `.json` file corresponding to each component from which React Intl messages were extracted.
+  - **`json-single-file`**: will output single `{locale}.json` file with all message ID-default message pairs for each of `locales`.
+  - **`xliff-1.2`**: will output single `{locale}.xliff` file with all messages from all files for each of `locales`.
+
+- **`locales`**: Array of strings for `json-single-file` & `xliff` formats.
+
+- **`messagesDir`**: The target location where the plugin will output data. If not provided, the extracted message descriptors will only be accessible via Babel's API.
+
+- **`enforceDefaultMessage`**: Whether message declarations _must_ contain a `defaultMessage`. Defaults to: `true`.
 
 - **`enforceDescriptions`**: Whether message declarations _must_ contain a `description` to provide context to translators. Defaults to: `false`.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 - **`format`**:
   - **`json-multi-file`** (default): will output a `.json` file corresponding to each component from which React Intl messages were extracted.
-  - **`json-single-file`**: will output single `{locale}.json` file with all message ID-default message pairs for each of `locales`.
-  - **`xliff-1.2`**: will output single `{locale}.xliff` file with all messages from all files for each of `locales`.
+  - **`json-single-file`**: will output single JSON file with all message ID-default message pairs.
+  - **`xliff-1.2`**: will output single [XLIFF 1.2](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html) file with each component in corresponding `<file>` element and each message in `<trans-unit>` element.
 
-- **`locales`**: Array of strings for `json-single-file` & `xliff` formats.
+- **`messagesDir`**: The target location where the plugin will output data for `json-multi-file` format. If not provided, the extracted message descriptors will only be accessible via Babel's API.
 
-- **`messagesDir`**: The target location where the plugin will output data. If not provided, the extracted message descriptors will only be accessible via Babel's API.
+- **`messagesFile`**: The target location where the plugin will output data for `json-single-file` & `xliff-1.2` formats.
+
+- **`xliffSourceLanguage`**: Source language for `xliff-1.2` format.
+
+- **`xliffTargetLanguage`**: Target language for `xliff-1.2` format.
 
 - **`enforceDefaultMessage`**: Whether message declarations _must_ contain a `defaultMessage`. Defaults to: `true`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,13 +16,13 @@ var _defineProperty2 = require('babel-runtime/helpers/defineProperty');
 
 var _defineProperty3 = _interopRequireDefault(_defineProperty2);
 
-var _assign = require('babel-runtime/core-js/object/assign');
-
-var _assign2 = _interopRequireDefault(_assign);
-
 var _getIterator2 = require('babel-runtime/core-js/get-iterator');
 
 var _getIterator3 = _interopRequireDefault(_getIterator2);
+
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
 
 var _stringify = require('babel-runtime/core-js/json/stringify');
 
@@ -216,6 +216,10 @@ exports.default = function (_ref) {
     var contentsCache = {};
 
     function generateJSONMultiFile(file, opts, descriptors) {
+        if (!opts.messagesDir) {
+            return;
+        }
+
         var _file$opts = file.opts,
             filename = _file$opts.filename,
             basename = _file$opts.basename;
@@ -234,6 +238,10 @@ exports.default = function (_ref) {
     }
 
     function generateJSONSingleFile(file, opts, descriptors) {
+        if (!opts.messagesFile) {
+            return;
+        }
+
         var messages = {};
 
         var _iteratorNormalCompletion = true;
@@ -261,59 +269,64 @@ exports.default = function (_ref) {
             }
         }
 
+        var localeFileName = opts.messagesFile;
+
+        var localeMessages = {};
+        var existingContentsHash = null;
+
+        if (existsCache[localeFileName] === undefined) {
+            existsCache[localeFileName] = (0, _fs.existsSync)(localeFileName);
+        }
+
+        if (existsCache[localeFileName]) {
+            if (contentsCache[localeFileName] === undefined) {
+                contentsCache[localeFileName] = {
+                    contents: (0, _fs.readFileSync)(localeFileName)
+                };
+                contentsCache[localeFileName].md5 = (0, _crypto.createHash)('md5').update(contentsCache[localeFileName].contents).digest('hex');
+            }
+
+            localeMessages = JSON.parse(contentsCache[localeFileName].contents);
+            existingContentsHash = contentsCache[localeFileName].md5;
+        }
+
+        localeMessages = (0, _assign2.default)({}, messages, localeMessages);
+        localeMessages = (0, _keys2.default)(localeMessages).sort().reduce(function (o, k) {
+            o[k] = localeMessages[k];
+            return o;
+        }, {});
+
+        var newContents = (0, _stringify2.default)(localeMessages, null, 2) + '\n';
+        var newContentsHash = (0, _crypto.createHash)('md5').update(newContents).digest('hex');
+
+        if (newContentsHash !== existingContentsHash) {
+            if (!existsCache[localeFileName]) {
+                (0, _mkdirp.sync)(opts.messagesDir);
+            }
+            (0, _fs.writeFileSync)(localeFileName, newContents);
+            existsCache[localeFileName] = true;
+            contentsCache[localeFileName] = {
+                contents: newContents,
+                md5: newContentsHash
+            };
+        }
+    }
+
+    function copyAddChildElement(doc, el, parent) {
+        var newEl = new _libxmljs.Element(doc, el.name());
+        parent.addChild(newEl);
+        newEl.namespace(el.namespace());
+
         var _iteratorNormalCompletion2 = true;
         var _didIteratorError2 = false;
         var _iteratorError2 = undefined;
 
         try {
-            var _loop = function _loop() {
-                var locale = _step2.value;
+            for (var _iterator2 = (0, _getIterator3.default)(el.attrs()), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                var attr = _step2.value;
 
-                var localeFileName = p.join(opts.messagesDir, locale + '.json');
-
-                var localeMessages = {};
-                var existingContentsHash = null;
-
-                if (existsCache[localeFileName] === undefined) {
-                    existsCache[localeFileName] = (0, _fs.existsSync)(localeFileName);
-                }
-
-                if (existsCache[localeFileName]) {
-                    if (contentsCache[localeFileName] === undefined) {
-                        contentsCache[localeFileName] = {
-                            contents: (0, _fs.readFileSync)(localeFileName)
-                        };
-                        contentsCache[localeFileName].md5 = (0, _crypto.createHash)('md5').update(contentsCache[localeFileName].contents).digest('hex');
-                    }
-
-                    localeMessages = JSON.parse(contentsCache[localeFileName].contents);
-                    existingContentsHash = contentsCache[localeFileName].md5;
-                }
-
-                localeMessages = (0, _assign2.default)({}, messages, localeMessages);
-                localeMessages = (0, _keys2.default)(localeMessages).sort().reduce(function (o, k) {
-                    o[k] = localeMessages[k];
-                    return o;
-                }, {});
-
-                var newContents = (0, _stringify2.default)(localeMessages, null, 2) + '\n';
-                var newContentsHash = (0, _crypto.createHash)('md5').update(newContents).digest('hex');
-
-                if (newContentsHash !== existingContentsHash) {
-                    if (!existsCache[localeFileName]) {
-                        (0, _mkdirp.sync)(opts.messagesDir);
-                    }
-                    (0, _fs.writeFileSync)(localeFileName, newContents);
-                    existsCache[localeFileName] = true;
-                    contentsCache[localeFileName] = {
-                        contents: newContents,
-                        md5: newContentsHash
-                    };
-                }
-            };
-
-            for (var _iterator2 = (0, _getIterator3.default)(opts.locales || []), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-                _loop();
+                newEl.attr((0, _defineProperty3.default)({}, attr.name(), attr.value()));
+                // FIXME: libxmljs does not handle attribute namespaces
             }
         } catch (err) {
             _didIteratorError2 = true;
@@ -329,23 +342,20 @@ exports.default = function (_ref) {
                 }
             }
         }
-    }
-
-    function copyAddChildElement(doc, el, parent) {
-        var newEl = new _libxmljs.Element(doc, el.name());
-        parent.addChild(newEl);
-        newEl.namespace(el.namespace());
 
         var _iteratorNormalCompletion3 = true;
         var _didIteratorError3 = false;
         var _iteratorError3 = undefined;
 
         try {
-            for (var _iterator3 = (0, _getIterator3.default)(el.attrs()), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-                var attr = _step3.value;
+            for (var _iterator3 = (0, _getIterator3.default)(el.childNodes()), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                var child = _step3.value;
 
-                newEl.attr((0, _defineProperty3.default)({}, attr.name(), attr.value()));
-                // FIXME: libxmljs does not handle attribute namespaces
+                if (child.type() === "element") {
+                    copyAddChildElement(doc, child, newEl);
+                } else {
+                    newEl.addChild(child);
+                }
             }
         } catch (err) {
             _didIteratorError3 = true;
@@ -362,18 +372,76 @@ exports.default = function (_ref) {
             }
         }
 
+        return newEl;
+    }
+
+    function generateXLIFF12(file, opts, descriptors) {
+        if (!opts.messagesFile) {
+            return;
+        }
+
+        var relativeFileName = p.relative(process.cwd(), file.opts.filename);
+
+        var localeFileName = opts.messagesFile;
+
+        if (existsCache[localeFileName] === undefined) {
+            existsCache[localeFileName] = (0, _fs.existsSync)(localeFileName);
+        }
+
+        var existingDoc = undefined;
+        var existingContentsHash = null;
+
+        if (existsCache[localeFileName]) {
+            if (contentsCache[localeFileName] === undefined) {
+                contentsCache[localeFileName] = {
+                    contents: (0, _fs.readFileSync)(localeFileName)
+                };
+                contentsCache[localeFileName].md5 = (0, _crypto.createHash)('md5').update(contentsCache[localeFileName].contents).digest('hex');
+            }
+
+            existingContentsHash = contentsCache[localeFileName].md5;
+            existingDoc = (0, _libxmljs.parseXml)(contentsCache[localeFileName].contents);
+
+            var versionAttribute = existingDoc.root().attr('version');
+
+            if (!versionAttribute || versionAttribute.value() !== '1.2') {
+                throw '[React Intl] File ' + localeFileName + ' is not XLIFF 1.2 file.';
+            }
+        } else {
+            existingDoc = new _libxmljs.Document('1.0', 'utf-8');
+            var _rootNode = new _libxmljs.Element(existingDoc, 'xliff');
+            _rootNode.defineNamespace(XLIFF12_NAMESPACE);
+            _rootNode.namespace(XLIFF12_NAMESPACE);
+            _rootNode.attr({
+                'version': '1.2'
+            });
+            existingDoc.root(_rootNode);
+        }
+
+        var newDoc = new _libxmljs.Document('1.0', 'utf-8');
+        var rootNode = new _libxmljs.Element(newDoc, 'xliff');
+        rootNode.defineNamespace(XLIFF12_NAMESPACE);
+        rootNode.namespace(XLIFF12_NAMESPACE);
+        rootNode.attr({
+            'version': '1.2'
+        });
+        newDoc.root(rootNode);
+
+        var appendFileNodes = [];
         var _iteratorNormalCompletion4 = true;
         var _didIteratorError4 = false;
         var _iteratorError4 = undefined;
 
         try {
-            for (var _iterator4 = (0, _getIterator3.default)(el.childNodes()), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-                var child = _step4.value;
+            for (var _iterator4 = (0, _getIterator3.default)(existingDoc.find('//xliff:file', { xliff: XLIFF12_NAMESPACE })), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                var existingFileNode = _step4.value;
 
-                if (child.type() === "element") {
-                    copyAddChildElement(doc, child, newEl);
-                } else {
-                    newEl.addChild(child);
+                var original = existingFileNode.attr('original').value();
+
+                if (original < relativeFileName) {
+                    copyAddChildElement(newDoc, existingFileNode, rootNode);
+                } else if (original > relativeFileName) {
+                    appendFileNodes.push(existingFileNode);
                 }
             }
         } catch (err) {
@@ -390,204 +458,60 @@ exports.default = function (_ref) {
                 }
             }
         }
-    }
 
-    function generateXLIFF12(file, opts, descriptors) {
-        var relativeFileName = p.relative(process.cwd(), file.opts.filename);
+        var fileNode = new _libxmljs.Element(newDoc, 'file');
+        rootNode.addChild(fileNode);
+        fileNode.namespace(XLIFF12_NAMESPACE);
+        fileNode.attr({
+            'original': relativeFileName,
+            'datatype': 'plaintext',
+            'source-language': opts.xliffSourceLanguage,
+            'target-language': opts.xliffTargetLanguage
+        });
+
+        var bodyNode = new _libxmljs.Element(newDoc, 'body');
+        fileNode.addChild(bodyNode);
+        bodyNode.namespace(XLIFF12_NAMESPACE);
 
         var _iteratorNormalCompletion5 = true;
         var _didIteratorError5 = false;
         var _iteratorError5 = undefined;
 
         try {
-            for (var _iterator5 = (0, _getIterator3.default)(opts.locales || []), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                var locale = _step5.value;
+            for (var _iterator5 = (0, _getIterator3.default)(descriptors), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                var _descriptor2 = _step5.value;
 
-                var _localeFileName = p.join(opts.messagesDir, locale + '.xliff');
+                var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
+                bodyNode.addChild(transUnitNode);
+                transUnitNode.namespace(XLIFF12_NAMESPACE);
+                transUnitNode.attr({
+                    id: _descriptor2.id
+                });
 
-                if (existsCache[_localeFileName] === undefined) {
-                    existsCache[_localeFileName] = (0, _fs.existsSync)(_localeFileName);
-                }
+                var sourceNode = new _libxmljs.Element(newDoc, 'source');
+                transUnitNode.addChild(sourceNode);
+                sourceNode.namespace(XLIFF12_NAMESPACE);
+                sourceNode.text(_descriptor2.id);
 
-                var existingDoc = undefined;
-                var _existingContentsHash = null;
+                var targetNode = new _libxmljs.Element(newDoc, 'target');
+                transUnitNode.addChild(targetNode);
+                targetNode.namespace(XLIFF12_NAMESPACE);
 
-                if (existsCache[_localeFileName]) {
-                    if (contentsCache[_localeFileName] === undefined) {
-                        contentsCache[_localeFileName] = {
-                            contents: (0, _fs.readFileSync)(_localeFileName)
-                        };
-                        contentsCache[_localeFileName].md5 = (0, _crypto.createHash)('md5').update(contentsCache[_localeFileName].contents).digest('hex');
-                    }
+                var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']\n                    /xliff:body\n                    /xliff:trans-unit[xliff:source[text() = \'' + _descriptor2.id + '\']]\n                    /xliff:target', {
+                    xliff: XLIFF12_NAMESPACE
+                });
 
-                    _existingContentsHash = contentsCache[_localeFileName].md5;
-                    existingDoc = (0, _libxmljs.parseXml)(contentsCache[_localeFileName].contents);
-
-                    var versionAttribute = existingDoc.root().attr('version');
-
-                    if (!versionAttribute || versionAttribute.value() !== '1.2') {
-                        throw '[React Intl] File ' + _localeFileName + ' is not XLIFF 1.2 file.';
-                    }
+                if (existingTargetNode) {
+                    targetNode.text(existingTargetNode.text().trim());
                 } else {
-                    existingDoc = new _libxmljs.Document('1.0', 'utf-8');
-                    var _rootNode = new _libxmljs.Element(existingDoc, 'xliff');
-                    _rootNode.defineNamespace(XLIFF12_NAMESPACE);
-                    _rootNode.namespace(XLIFF12_NAMESPACE);
-                    _rootNode.attr({
-                        'version': '1.2'
-                    });
-                    existingDoc.root(_rootNode);
+                    targetNode.text(_descriptor2.defaultMessage);
                 }
 
-                var newDoc = new _libxmljs.Document('1.0', 'utf-8');
-                var rootNode = new _libxmljs.Element(newDoc, 'xliff');
-                rootNode.defineNamespace(XLIFF12_NAMESPACE);
-                rootNode.namespace(XLIFF12_NAMESPACE);
-                rootNode.attr({
-                    'version': '1.2'
-                });
-                newDoc.root(rootNode);
-
-                var appendFileNodes = [];
-                var _iteratorNormalCompletion6 = true;
-                var _didIteratorError6 = false;
-                var _iteratorError6 = undefined;
-
-                try {
-                    for (var _iterator6 = (0, _getIterator3.default)(existingDoc.find('//xliff:file', { xliff: XLIFF12_NAMESPACE })), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
-                        var existingFileNode = _step6.value;
-
-                        var original = existingFileNode.attr('original').value();
-
-                        if (original < relativeFileName) {
-                            copyAddChildElement(newDoc, existingFileNode, rootNode);
-                        } else if (original > relativeFileName) {
-                            appendFileNodes.push(existingFileNode);
-                        }
-                    }
-                } catch (err) {
-                    _didIteratorError6 = true;
-                    _iteratorError6 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion6 && _iterator6.return) {
-                            _iterator6.return();
-                        }
-                    } finally {
-                        if (_didIteratorError6) {
-                            throw _iteratorError6;
-                        }
-                    }
-                }
-
-                var fileNode = new _libxmljs.Element(newDoc, 'file');
-                rootNode.addChild(fileNode);
-                fileNode.namespace(XLIFF12_NAMESPACE);
-                fileNode.attr({
-                    'original': relativeFileName,
-                    'datatype': 'plaintext',
-                    'source-language': 'en',
-                    'target-language': locale
-                });
-
-                var bodyNode = new _libxmljs.Element(newDoc, 'body');
-                fileNode.addChild(bodyNode);
-                bodyNode.namespace(XLIFF12_NAMESPACE);
-
-                var _iteratorNormalCompletion7 = true;
-                var _didIteratorError7 = false;
-                var _iteratorError7 = undefined;
-
-                try {
-                    for (var _iterator7 = (0, _getIterator3.default)(descriptors), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
-                        var _descriptor2 = _step7.value;
-
-                        var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
-                        bodyNode.addChild(transUnitNode);
-                        transUnitNode.namespace(XLIFF12_NAMESPACE);
-                        transUnitNode.attr({
-                            id: _descriptor2.id
-                        });
-
-                        var sourceNode = new _libxmljs.Element(newDoc, 'source');
-                        transUnitNode.addChild(sourceNode);
-                        sourceNode.namespace(XLIFF12_NAMESPACE);
-                        sourceNode.text(_descriptor2.id);
-
-                        var targetNode = new _libxmljs.Element(newDoc, 'target');
-                        transUnitNode.addChild(targetNode);
-                        targetNode.namespace(XLIFF12_NAMESPACE);
-
-                        var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']/xliff:body/xliff:trans-unit[xliff:source[text() = \'' + _descriptor2.id + '\']]/xliff:target', {
-                            xliff: XLIFF12_NAMESPACE
-                        });
-
-                        if (existingTargetNode) {
-                            targetNode.text(existingTargetNode.text().trim());
-                        } else {
-                            targetNode.text(_descriptor2.defaultMessage);
-                        }
-
-                        if (_descriptor2.description) {
-                            var noteNode = new _libxmljs.Element(newDoc, 'note');
-                            transUnitNode.addChild(noteNode);
-                            noteNode.namespace(XLIFF12_NAMESPACE);
-                            noteNode.text(_descriptor2.description);
-                        }
-                    }
-                } catch (err) {
-                    _didIteratorError7 = true;
-                    _iteratorError7 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion7 && _iterator7.return) {
-                            _iterator7.return();
-                        }
-                    } finally {
-                        if (_didIteratorError7) {
-                            throw _iteratorError7;
-                        }
-                    }
-                }
-
-                var _iteratorNormalCompletion8 = true;
-                var _didIteratorError8 = false;
-                var _iteratorError8 = undefined;
-
-                try {
-                    for (var _iterator8 = (0, _getIterator3.default)(appendFileNodes), _step8; !(_iteratorNormalCompletion8 = (_step8 = _iterator8.next()).done); _iteratorNormalCompletion8 = true) {
-                        var _existingFileNode = _step8.value;
-
-                        copyAddChildElement(newDoc, _existingFileNode, rootNode);
-                    }
-                } catch (err) {
-                    _didIteratorError8 = true;
-                    _iteratorError8 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion8 && _iterator8.return) {
-                            _iterator8.return();
-                        }
-                    } finally {
-                        if (_didIteratorError8) {
-                            throw _iteratorError8;
-                        }
-                    }
-                }
-
-                var _newContents = newDoc.toString(true).trim() + '\n';
-                var _newContentsHash = (0, _crypto.createHash)('md5').update(_newContents).digest('hex');
-
-                if (_newContentsHash !== _existingContentsHash) {
-                    if (!existsCache[_localeFileName]) {
-                        (0, _mkdirp.sync)(opts.messagesDir);
-                    }
-                    (0, _fs.writeFileSync)(_localeFileName, _newContents);
-                    existsCache[_localeFileName] = true;
-                    contentsCache[_localeFileName] = {
-                        contents: _newContents,
-                        md5: _newContentsHash
-                    };
+                if (_descriptor2.description) {
+                    var noteNode = new _libxmljs.Element(newDoc, 'note');
+                    transUnitNode.addChild(noteNode);
+                    noteNode.namespace(XLIFF12_NAMESPACE);
+                    noteNode.text(_descriptor2.description);
                 }
             }
         } catch (err) {
@@ -603,6 +527,46 @@ exports.default = function (_ref) {
                     throw _iteratorError5;
                 }
             }
+        }
+
+        var _iteratorNormalCompletion6 = true;
+        var _didIteratorError6 = false;
+        var _iteratorError6 = undefined;
+
+        try {
+            for (var _iterator6 = (0, _getIterator3.default)(appendFileNodes), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+                var _existingFileNode = _step6.value;
+
+                copyAddChildElement(newDoc, _existingFileNode, rootNode);
+            }
+        } catch (err) {
+            _didIteratorError6 = true;
+            _iteratorError6 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion6 && _iterator6.return) {
+                    _iterator6.return();
+                }
+            } finally {
+                if (_didIteratorError6) {
+                    throw _iteratorError6;
+                }
+            }
+        }
+
+        var newContents = newDoc.toString(true).trim() + '\n';
+        var newContentsHash = (0, _crypto.createHash)('md5').update(newContents).digest('hex');
+
+        if (newContentsHash !== existingContentsHash) {
+            if (!existsCache[localeFileName]) {
+                (0, _mkdirp.sync)(opts.messagesDir);
+            }
+            (0, _fs.writeFileSync)(localeFileName, newContents);
+            existsCache[localeFileName] = true;
+            contentsCache[localeFileName] = {
+                contents: newContents,
+                md5: newContentsHash
+            };
         }
     }
 
@@ -633,7 +597,7 @@ exports.default = function (_ref) {
 
             file.metadata['react-intl'] = { messages: descriptors };
 
-            if (opts.messagesDir && descriptors.length > 0) {
+            if (descriptors.length > 0) {
                 var generate = generators[opts.format || FORMAT_JSON_MULTI_FILE];
 
                 if (!generate) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,440 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
+
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
+var _getIterator2 = require('babel-runtime/core-js/get-iterator');
+
+var _getIterator3 = _interopRequireDefault(_getIterator2);
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+var _map = require('babel-runtime/core-js/map');
+
+var _map2 = _interopRequireDefault(_map);
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _typeof2 = require('babel-runtime/helpers/typeof');
+
+var _typeof3 = _interopRequireDefault(_typeof2);
+
+var _keys = require('babel-runtime/core-js/object/keys');
+
+var _keys2 = _interopRequireDefault(_keys);
+
+var _objectWithoutProperties2 = require('babel-runtime/helpers/objectWithoutProperties');
+
+var _objectWithoutProperties3 = _interopRequireDefault(_objectWithoutProperties2);
+
+var _slicedToArray2 = require('babel-runtime/helpers/slicedToArray');
+
+var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
+
+var _symbol = require('babel-runtime/core-js/symbol');
+
+var _symbol2 = _interopRequireDefault(_symbol);
+
+var _set = require('babel-runtime/core-js/set');
+
+var _set2 = _interopRequireDefault(_set);
+
+exports.default = function (_ref) {
+    var t = _ref.types;
+
+    function getModuleSourceName(opts) {
+        return opts.moduleSourceName || 'react-intl';
+    }
+
+    function evaluatePath(path) {
+        var evaluated = path.evaluate();
+        if (evaluated.confident) {
+            return evaluated.value;
+        }
+
+        throw path.buildCodeFrameError('[React Intl] Messages must be statically evaluate-able for extraction.');
+    }
+
+    function getMessageDescriptorKey(path) {
+        if (path.isIdentifier() || path.isJSXIdentifier()) {
+            return path.node.name;
+        }
+
+        return evaluatePath(path);
+    }
+
+    function getMessageDescriptorValue(path) {
+        if (path.isJSXExpressionContainer()) {
+            path = path.get('expression');
+        }
+
+        // Always trim the Message Descriptor values.
+        var descriptorValue = evaluatePath(path);
+
+        if (typeof descriptorValue === 'string') {
+            return descriptorValue.trim();
+        }
+
+        return descriptorValue;
+    }
+
+    function getICUMessageValue(messagePath) {
+        var _ref2 = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        var _ref2$isJSXSource = _ref2.isJSXSource;
+        var isJSXSource = _ref2$isJSXSource === undefined ? false : _ref2$isJSXSource;
+
+        var message = getMessageDescriptorValue(messagePath);
+
+        try {
+            return (0, _printIcuMessage2.default)(message);
+        } catch (parseError) {
+            if (isJSXSource && messagePath.isLiteral() && message.indexOf('\\\\') >= 0) {
+
+                throw messagePath.buildCodeFrameError('[React Intl] Message failed to parse. ' + 'It looks like `\\`s were used for escaping, ' + 'this won\'t work with JSX string literals. ' + 'Wrap with `{}`. ' + 'See: http://facebook.github.io/react/docs/jsx-gotchas.html');
+            }
+
+            throw messagePath.buildCodeFrameError('[React Intl] Message failed to parse. ' + 'See: http://formatjs.io/guides/message-syntax/' + ('\n' + parseError));
+        }
+    }
+
+    function createMessageDescriptor(propPaths) {
+        return propPaths.reduce(function (hash, _ref3) {
+            var _ref4 = (0, _slicedToArray3.default)(_ref3, 2);
+
+            var keyPath = _ref4[0];
+            var valuePath = _ref4[1];
+
+            var key = getMessageDescriptorKey(keyPath);
+
+            if (DESCRIPTOR_PROPS.has(key)) {
+                hash[key] = valuePath;
+            }
+
+            return hash;
+        }, {});
+    }
+
+    function evaluateMessageDescriptor(_ref5) {
+        var descriptor = (0, _objectWithoutProperties3.default)(_ref5, []);
+
+        var _ref6 = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+        var _ref6$isJSXSource = _ref6.isJSXSource;
+        var isJSXSource = _ref6$isJSXSource === undefined ? false : _ref6$isJSXSource;
+
+        (0, _keys2.default)(descriptor).forEach(function (key) {
+            var valuePath = descriptor[key];
+
+            if (key === 'defaultMessage') {
+                descriptor[key] = getICUMessageValue(valuePath, { isJSXSource: isJSXSource });
+            } else {
+                descriptor[key] = getMessageDescriptorValue(valuePath);
+            }
+        });
+
+        return descriptor;
+    }
+
+    function storeMessage(_ref7, path, state) {
+        var id = _ref7.id;
+        var description = _ref7.description;
+        var defaultMessage = _ref7.defaultMessage;
+        var file = state.file;
+        var opts = state.opts;
+
+
+        if (!id) {
+            throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id`.');
+        }
+
+        var messages = file.get(MESSAGES);
+        if (messages.has(id)) {
+            var existing = messages.get(id);
+
+            if (description !== existing.description || defaultMessage !== existing.defaultMessage) {
+
+                throw path.buildCodeFrameError('[React Intl] Duplicate message id: "' + id + '", ' + 'but the `description` and/or `defaultMessage` are different.');
+            }
+        }
+
+        if (opts.enforceDescriptions) {
+            if (!description || (typeof description === 'undefined' ? 'undefined' : (0, _typeof3.default)(description)) === 'object' && (0, _keys2.default)(description).length < 1) {
+                throw path.buildCodeFrameError('[React Intl] Message must have a `description`.');
+            }
+        }
+
+        var loc = void 0;
+        if (opts.extractSourceLocation) {
+            loc = (0, _extends3.default)({
+                file: p.relative(process.cwd(), file.opts.filename)
+            }, path.node.loc);
+        }
+
+        messages.set(id, (0, _extends3.default)({ id: id, description: description, defaultMessage: defaultMessage || id }, loc));
+    }
+
+    function referencesImport(path, mod, importedNames) {
+        if (!(path.isIdentifier() || path.isJSXIdentifier())) {
+            return false;
+        }
+
+        return importedNames.some(function (name) {
+            return path.referencesImport(mod, name);
+        });
+    }
+
+    function tagAsExtracted(path) {
+        path.node[EXTRACTED] = true;
+    }
+
+    function wasExtracted(path) {
+        return !!path.node[EXTRACTED];
+    }
+
+    return {
+        pre: function pre(file) {
+            if (!file.has(MESSAGES)) {
+                file.set(MESSAGES, new _map2.default());
+            }
+        },
+        post: function post(file) {
+            var opts = this.opts;
+
+
+            var messages = file.get(MESSAGES);
+            var descriptors = [].concat((0, _toConsumableArray3.default)(messages.values()));
+            file.metadata['react-intl'] = { messages: descriptors };
+
+            if (opts.messagesDir && opts.locales && opts.locales.length > 0 && descriptors.length > 0) {
+                var defaultLocale = opts.locales[0];
+
+                (0, _mkdirp.sync)(opts.messagesDir);
+
+                var _messages = {};
+                var _iteratorNormalCompletion = true;
+                var _didIteratorError = false;
+                var _iteratorError = undefined;
+
+                try {
+                    for (var _iterator = (0, _getIterator3.default)(descriptors), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                        var descriptor = _step.value;
+
+                        _messages[descriptor.id] = descriptor.defaultMessage;
+                    }
+                } catch (err) {
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return) {
+                            _iterator.return();
+                        }
+                    } finally {
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                }
+
+                var _iteratorNormalCompletion2 = true;
+                var _didIteratorError2 = false;
+                var _iteratorError2 = undefined;
+
+                try {
+                    var _loop = function _loop() {
+                        var locale = _step2.value;
+
+                        var localeFilename = p.join(opts.messagesDir, locale + ".json");
+
+                        var localeMessages = {};
+
+                        if ((0, _fs.existsSync)(localeFilename)) {
+                            try {
+                                localeMessages = JSON.parse((0, _fs.readFileSync)(localeFilename));
+                            } catch (e) {
+                                localeMessages = {};
+                            }
+                        }
+
+                        if (locale === defaultLocale) {
+                            localeMessages = (0, _assign2.default)({}, localeMessages, _messages);
+                        } else {
+                            localeMessages = (0, _assign2.default)({}, _messages, localeMessages);
+                        }
+                        localeMessages = (0, _keys2.default)(localeMessages).sort().reduce(function (o, k) {
+                            o[k] = localeMessages[k];
+                            return o;
+                        }, {});
+
+                        (0, _fs.writeFileSync)(localeFilename, (0, _stringify2.default)(localeMessages, null, 2) + "\n");
+                    };
+
+                    for (var _iterator2 = (0, _getIterator3.default)(opts.locales), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                        _loop();
+                    }
+                } catch (err) {
+                    _didIteratorError2 = true;
+                    _iteratorError2 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                            _iterator2.return();
+                        }
+                    } finally {
+                        if (_didIteratorError2) {
+                            throw _iteratorError2;
+                        }
+                    }
+                }
+            }
+        },
+
+
+        visitor: {
+            JSXOpeningElement: function JSXOpeningElement(path, state) {
+                if (wasExtracted(path)) {
+                    return;
+                }
+
+                var file = state.file;
+                var opts = state.opts;
+
+                var moduleSourceName = getModuleSourceName(opts);
+                var name = path.get('name');
+
+                if (name.referencesImport(moduleSourceName, 'FormattedPlural')) {
+                    file.log.warn('[React Intl] Line ' + path.node.loc.start.line + ': ' + 'Default messages are not extracted from ' + '<FormattedPlural>, use <FormattedMessage> instead.');
+
+                    return;
+                }
+
+                if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
+                    var attributes = path.get('attributes').filter(function (attr) {
+                        return attr.isJSXAttribute();
+                    });
+
+                    var descriptor = createMessageDescriptor(attributes.map(function (attr) {
+                        return [attr.get('name'), attr.get('value')];
+                    }));
+
+                    // In order for a default message to be extracted when
+                    // declaring a JSX element, it must be done with standard
+                    // `key=value` attributes. But it's completely valid to
+                    // write `<FormattedMessage {...descriptor} />`, because
+                    // it will be skipped here and extracted elsewhere.
+                    // The descriptor will be extracted only if a `id` prop exists.
+                    if (descriptor.id) {
+                        // Evaluate the Message Descriptor values in a JSX
+                        // context, then store it.
+                        descriptor = evaluateMessageDescriptor(descriptor, {
+                            isJSXSource: true
+                        });
+
+                        storeMessage(descriptor, path, state);
+
+                        // Remove description since it's not used at runtime.
+                        attributes.some(function (attr) {
+                            var ketPath = attr.get('name');
+                            if (getMessageDescriptorKey(ketPath) === 'description') {
+                                attr.remove();
+                                return true;
+                            }
+                        });
+
+                        // Tag the AST node so we don't try to extract it twice.
+                        tagAsExtracted(path);
+                    }
+                }
+            },
+            CallExpression: function CallExpression(path, state) {
+                var moduleSourceName = getModuleSourceName(state.opts);
+                var callee = path.get('callee');
+
+                function assertObjectExpression(node) {
+                    if (!(node && node.isObjectExpression())) {
+                        throw path.buildCodeFrameError('[React Intl] `' + callee.node.name + '()` must be ' + 'called with an object expression with values ' + 'that are React Intl Message Descriptors, also ' + 'defined as object expressions.');
+                    }
+                }
+
+                function processMessageObject(messageObj) {
+                    assertObjectExpression(messageObj);
+
+                    if (wasExtracted(messageObj)) {
+                        return;
+                    }
+
+                    var properties = messageObj.get('properties');
+
+                    var descriptor = createMessageDescriptor(properties.map(function (prop) {
+                        return [prop.get('key'), prop.get('value')];
+                    }));
+
+                    // Evaluate the Message Descriptor values, then store it.
+                    descriptor = evaluateMessageDescriptor(descriptor);
+                    storeMessage(descriptor, messageObj, state);
+
+                    // Remove description since it's not used at runtime.
+                    messageObj.replaceWith(t.objectExpression([t.objectProperty(t.stringLiteral('id'), t.stringLiteral(descriptor.id)), t.objectProperty(t.stringLiteral('defaultMessage'), t.stringLiteral(descriptor.defaultMessage))]));
+
+                    // Tag the AST node so we don't try to extract it twice.
+                    tagAsExtracted(messageObj);
+                }
+
+                if (referencesImport(callee, moduleSourceName, FUNCTION_NAMES)) {
+                    var messagesObj = path.get('arguments')[0];
+
+                    assertObjectExpression(messagesObj);
+
+                    messagesObj.get('properties').map(function (prop) {
+                        return prop.get('value');
+                    }).forEach(processMessageObject);
+                }
+            }
+        }
+    };
+};
+
+var _path = require('path');
+
+var p = _interopRequireWildcard(_path);
+
+var _fs = require('fs');
+
+var _mkdirp = require('mkdirp');
+
+var _printIcuMessage = require('./print-icu-message');
+
+var _printIcuMessage2 = _interopRequireDefault(_printIcuMessage);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+var COMPONENT_NAMES = ['FormattedMessage', 'FormattedHTMLMessage'];
+
+var FUNCTION_NAMES = ['defineMessages'];
+
+var DESCRIPTOR_PROPS = new _set2.default(['id', 'description', 'defaultMessage']);
+
+var EXTRACTED = (0, _symbol2.default)('ReactIntlExtracted');
+var MESSAGES = (0, _symbol2.default)('ReactIntlMessages');

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,6 +159,7 @@ exports.default = function (_ref) {
         var file = state.file,
             opts = state.opts;
 
+
         if (!id) {
             throw path.buildCodeFrameError('[React Intl] Message descriptors require an `id`.');
         }
@@ -184,7 +185,7 @@ exports.default = function (_ref) {
             }
         }
 
-        var loc = undefined;
+        var loc = void 0;
         if (opts.extractSourceLocation) {
             loc = (0, _extends3.default)({
                 file: p.relative(process.cwd(), file.opts.filename)
@@ -250,9 +251,9 @@ exports.default = function (_ref) {
 
         try {
             for (var _iterator = (0, _getIterator3.default)(descriptors), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                var _descriptor = _step.value;
+                var descriptor = _step.value;
 
-                messages[_descriptor.id] = _descriptor.defaultMessage;
+                messages[descriptor.id] = descriptor.defaultMessage;
             }
         } catch (err) {
             _didIteratorError = true;
@@ -351,7 +352,7 @@ exports.default = function (_ref) {
             for (var _iterator3 = (0, _getIterator3.default)(el.childNodes()), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
                 var child = _step3.value;
 
-                if (child.type() === "element") {
+                if (child.type() === 'element') {
                     copyAddChildElement(doc, child, newEl);
                 } else {
                     newEl.addChild(child);
@@ -388,7 +389,7 @@ exports.default = function (_ref) {
             existsCache[localeFileName] = (0, _fs.existsSync)(localeFileName);
         }
 
-        var existingDoc = undefined;
+        var existingDoc = void 0;
         var existingContentsHash = null;
 
         if (existsCache[localeFileName]) {
@@ -479,39 +480,39 @@ exports.default = function (_ref) {
 
         try {
             for (var _iterator5 = (0, _getIterator3.default)(descriptors), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                var _descriptor2 = _step5.value;
+                var descriptor = _step5.value;
 
                 var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
                 bodyNode.addChild(transUnitNode);
                 transUnitNode.namespace(XLIFF12_NAMESPACE);
                 transUnitNode.attr({
-                    id: _descriptor2.id
+                    id: descriptor.id
                 });
 
                 var sourceNode = new _libxmljs.Element(newDoc, 'source');
                 transUnitNode.addChild(sourceNode);
                 sourceNode.namespace(XLIFF12_NAMESPACE);
-                sourceNode.text(_descriptor2.id);
+                sourceNode.text(descriptor.id);
 
                 var targetNode = new _libxmljs.Element(newDoc, 'target');
                 transUnitNode.addChild(targetNode);
                 targetNode.namespace(XLIFF12_NAMESPACE);
 
-                var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']\n                    /xliff:body\n                    /xliff:trans-unit[xliff:source[text() = \'' + _descriptor2.id + '\']]\n                    /xliff:target', {
+                var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']\n                    /xliff:body\n                    /xliff:trans-unit[xliff:source[text() = \'' + descriptor.id + '\']]\n                    /xliff:target', {
                     xliff: XLIFF12_NAMESPACE
                 });
 
                 if (existingTargetNode) {
                     targetNode.text(existingTargetNode.text().trim());
                 } else {
-                    targetNode.text(_descriptor2.defaultMessage);
+                    targetNode.text(descriptor.defaultMessage);
                 }
 
-                if (_descriptor2.description) {
+                if (descriptor.description) {
                     var noteNode = new _libxmljs.Element(newDoc, 'note');
                     transUnitNode.addChild(noteNode);
                     noteNode.namespace(XLIFF12_NAMESPACE);
-                    noteNode.text(_descriptor2.description);
+                    noteNode.text(descriptor.description);
                 }
             }
         } catch (err) {
@@ -580,7 +581,7 @@ exports.default = function (_ref) {
         },
         post: function post(file) {
             var opts = this.opts;
-            var fileName = file.opts.filename;
+
 
             var messages = file.get(MESSAGES);
             var descriptors = [].concat((0, _toConsumableArray3.default)(messages.values()));
@@ -590,9 +591,9 @@ exports.default = function (_ref) {
                     return -1;
                 } else if (a.id > b.id) {
                     return 1;
-                } else {
-                    return 0;
                 }
+
+                return 0;
             });
 
             file.metadata['react-intl'] = { messages: descriptors };
@@ -607,6 +608,7 @@ exports.default = function (_ref) {
                 generate(file, opts, descriptors);
             }
         },
+
 
         visitor: {
             JSXOpeningElement: function JSXOpeningElement(path, state) {
@@ -631,7 +633,7 @@ exports.default = function (_ref) {
                         return attr.isJSXAttribute();
                     });
 
-                    var _descriptor3 = createMessageDescriptor(attributes.map(function (attr) {
+                    var descriptor = createMessageDescriptor(attributes.map(function (attr) {
                         return [attr.get('name'), attr.get('value')];
                     }));
 
@@ -641,14 +643,14 @@ exports.default = function (_ref) {
                     // write `<FormattedMessage {...descriptor} />`, because
                     // it will be skipped here and extracted elsewhere.
                     // The descriptor will be extracted only if a `id` prop exists.
-                    if (_descriptor3.id) {
+                    if (descriptor.id) {
                         // Evaluate the Message Descriptor values in a JSX
                         // context, then store it.
-                        _descriptor3 = evaluateMessageDescriptor(_descriptor3, {
+                        descriptor = evaluateMessageDescriptor(descriptor, {
                             isJSXSource: true
                         });
 
-                        storeMessage(_descriptor3, path, state);
+                        storeMessage(descriptor, path, state);
 
                         // Remove description since it's not used at runtime.
                         attributes.some(function (attr) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,6 @@ exports.default = function (_ref) {
         var file = state.file,
             opts = state.opts;
 
-
         if (!id) {
             throw path.buildCodeFrameError('[React Intl] Message descriptors require an `id`.');
         }
@@ -174,8 +173,8 @@ exports.default = function (_ref) {
         if (messages.has(id)) {
             var existing = messages.get(id);
 
-            if (description !== existing.description || (defaultMessage || id) !== existing.defaultMessage) {
-                throw path.buildCodeFrameError('[React Intl] Duplicate message id: "' + id + '", ' + 'but the `description` and/or `defaultMessage` are different.');
+            if (description !== existing.description || defaultMessage !== existing.defaultMessage) {
+                throw path.buildCodeFrameError('[React Intl] Duplicate message id: "' + id + '", ' + 'but the `description` and/or `defaultMessage` are different: ' + ('existing description [' + existing.description + '], new description [' + description + '], ') + ('existing default message [' + existing.defaultMessage + '], new default message [' + defaultMessage + '].'));
             }
         }
 
@@ -185,14 +184,14 @@ exports.default = function (_ref) {
             }
         }
 
-        var loc = void 0;
+        var loc = undefined;
         if (opts.extractSourceLocation) {
             loc = (0, _extends3.default)({
                 file: p.relative(process.cwd(), file.opts.filename)
             }, path.node.loc);
         }
 
-        messages.set(id, (0, _extends3.default)({ id: id, description: description, defaultMessage: defaultMessage || id }, loc));
+        messages.set(id, (0, _extends3.default)({ id: id, description: description, defaultMessage: defaultMessage }, loc));
     }
 
     function referencesImport(path, mod, importedNames) {
@@ -251,9 +250,9 @@ exports.default = function (_ref) {
 
         try {
             for (var _iterator = (0, _getIterator3.default)(descriptors), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                var descriptor = _step.value;
+                var _descriptor = _step.value;
 
-                messages[descriptor.id] = descriptor.defaultMessage;
+                messages[_descriptor.id] = _descriptor.defaultMessage || _descriptor.id;
             }
         } catch (err) {
             _didIteratorError = true;
@@ -389,7 +388,7 @@ exports.default = function (_ref) {
             existsCache[localeFileName] = (0, _fs.existsSync)(localeFileName);
         }
 
-        var existingDoc = void 0;
+        var existingDoc = undefined;
         var existingContentsHash = null;
 
         if (existsCache[localeFileName]) {
@@ -480,39 +479,39 @@ exports.default = function (_ref) {
 
         try {
             for (var _iterator5 = (0, _getIterator3.default)(descriptors), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                var descriptor = _step5.value;
+                var _descriptor2 = _step5.value;
 
                 var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
                 bodyNode.addChild(transUnitNode);
                 transUnitNode.namespace(XLIFF12_NAMESPACE);
                 transUnitNode.attr({
-                    id: descriptor.id
+                    id: _descriptor2.id
                 });
 
                 var sourceNode = new _libxmljs.Element(newDoc, 'source');
                 transUnitNode.addChild(sourceNode);
                 sourceNode.namespace(XLIFF12_NAMESPACE);
-                sourceNode.text(descriptor.id);
+                sourceNode.text(_descriptor2.id);
 
                 var targetNode = new _libxmljs.Element(newDoc, 'target');
                 transUnitNode.addChild(targetNode);
                 targetNode.namespace(XLIFF12_NAMESPACE);
 
-                var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']\n                    /xliff:body\n                    /xliff:trans-unit[xliff:source[text() = \'' + descriptor.id + '\']]\n                    /xliff:target', {
+                var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']\n                    /xliff:body\n                    /xliff:trans-unit[xliff:source[text() = \'' + _descriptor2.id + '\']]\n                    /xliff:target', {
                     xliff: XLIFF12_NAMESPACE
                 });
 
                 if (existingTargetNode) {
                     targetNode.text(existingTargetNode.text().trim());
                 } else {
-                    targetNode.text(descriptor.defaultMessage);
+                    targetNode.text(_descriptor2.defaultMessage || _descriptor2.id);
                 }
 
-                if (descriptor.description) {
+                if (_descriptor2.description) {
                     var noteNode = new _libxmljs.Element(newDoc, 'note');
                     transUnitNode.addChild(noteNode);
                     noteNode.namespace(XLIFF12_NAMESPACE);
-                    noteNode.text(descriptor.description);
+                    noteNode.text(_descriptor2.description);
                 }
             }
         } catch (err) {
@@ -582,7 +581,6 @@ exports.default = function (_ref) {
         post: function post(file) {
             var opts = this.opts;
 
-
             var messages = file.get(MESSAGES);
             var descriptors = [].concat((0, _toConsumableArray3.default)(messages.values()));
 
@@ -609,7 +607,6 @@ exports.default = function (_ref) {
             }
         },
 
-
         visitor: {
             JSXOpeningElement: function JSXOpeningElement(path, state) {
                 if (wasExtracted(path)) {
@@ -633,7 +630,7 @@ exports.default = function (_ref) {
                         return attr.isJSXAttribute();
                     });
 
-                    var descriptor = createMessageDescriptor(attributes.map(function (attr) {
+                    var _descriptor3 = createMessageDescriptor(attributes.map(function (attr) {
                         return [attr.get('name'), attr.get('value')];
                     }));
 
@@ -643,14 +640,14 @@ exports.default = function (_ref) {
                     // write `<FormattedMessage {...descriptor} />`, because
                     // it will be skipped here and extracted elsewhere.
                     // The descriptor will be extracted only if a `id` prop exists.
-                    if (descriptor.id) {
+                    if (_descriptor3.id) {
                         // Evaluate the Message Descriptor values in a JSX
                         // context, then store it.
-                        descriptor = evaluateMessageDescriptor(descriptor, {
+                        _descriptor3 = evaluateMessageDescriptor(_descriptor3, {
                             isJSXSource: true
                         });
 
-                        storeMessage(descriptor, path, state);
+                        storeMessage(_descriptor3, path, state);
 
                         // Remove description since it's not used at runtime.
                         attributes.some(function (attr) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,17 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
-var _stringify = require('babel-runtime/core-js/json/stringify');
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
 
-var _stringify2 = _interopRequireDefault(_stringify);
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+var _map = require('babel-runtime/core-js/map');
+
+var _map2 = _interopRequireDefault(_map);
+
+var _defineProperty2 = require('babel-runtime/helpers/defineProperty');
+
+var _defineProperty3 = _interopRequireDefault(_defineProperty2);
 
 var _assign = require('babel-runtime/core-js/object/assign');
 
@@ -16,13 +24,9 @@ var _getIterator2 = require('babel-runtime/core-js/get-iterator');
 
 var _getIterator3 = _interopRequireDefault(_getIterator2);
 
-var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+var _stringify = require('babel-runtime/core-js/json/stringify');
 
-var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
-
-var _map = require('babel-runtime/core-js/map');
-
-var _map2 = _interopRequireDefault(_map);
+var _stringify2 = _interopRequireDefault(_stringify);
 
 var _extends2 = require('babel-runtime/helpers/extends');
 
@@ -53,6 +57,8 @@ var _set = require('babel-runtime/core-js/set');
 var _set2 = _interopRequireDefault(_set);
 
 exports.default = function (_ref) {
+    var _generators;
+
     var t = _ref.types;
 
     function getModuleSourceName(opts) {
@@ -92,10 +98,9 @@ exports.default = function (_ref) {
     }
 
     function getICUMessageValue(messagePath) {
-        var _ref2 = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-        var _ref2$isJSXSource = _ref2.isJSXSource;
-        var isJSXSource = _ref2$isJSXSource === undefined ? false : _ref2$isJSXSource;
+        var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+            _ref2$isJSXSource = _ref2.isJSXSource,
+            isJSXSource = _ref2$isJSXSource === undefined ? false : _ref2$isJSXSource;
 
         var message = getMessageDescriptorValue(messagePath);
 
@@ -113,10 +118,9 @@ exports.default = function (_ref) {
 
     function createMessageDescriptor(propPaths) {
         return propPaths.reduce(function (hash, _ref3) {
-            var _ref4 = (0, _slicedToArray3.default)(_ref3, 2);
-
-            var keyPath = _ref4[0];
-            var valuePath = _ref4[1];
+            var _ref4 = (0, _slicedToArray3.default)(_ref3, 2),
+                keyPath = _ref4[0],
+                valuePath = _ref4[1];
 
             var key = getMessageDescriptorKey(keyPath);
 
@@ -129,12 +133,11 @@ exports.default = function (_ref) {
     }
 
     function evaluateMessageDescriptor(_ref5) {
+        var _ref6 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+            _ref6$isJSXSource = _ref6.isJSXSource,
+            isJSXSource = _ref6$isJSXSource === undefined ? false : _ref6$isJSXSource;
+
         var descriptor = (0, _objectWithoutProperties3.default)(_ref5, []);
-
-        var _ref6 = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-        var _ref6$isJSXSource = _ref6.isJSXSource;
-        var isJSXSource = _ref6$isJSXSource === undefined ? false : _ref6$isJSXSource;
 
         (0, _keys2.default)(descriptor).forEach(function (key) {
             var valuePath = descriptor[key];
@@ -150,23 +153,28 @@ exports.default = function (_ref) {
     }
 
     function storeMessage(_ref7, path, state) {
-        var id = _ref7.id;
-        var description = _ref7.description;
-        var defaultMessage = _ref7.defaultMessage;
-        var file = state.file;
-        var opts = state.opts;
+        var id = _ref7.id,
+            description = _ref7.description,
+            defaultMessage = _ref7.defaultMessage;
+        var file = state.file,
+            opts = state.opts;
 
 
         if (!id) {
-            throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id`.');
+            throw path.buildCodeFrameError('[React Intl] Message descriptors require an `id`.');
+        }
+
+        if (opts.enforceDefaultMessage === undefined || opts.enforceDefaultMessage === true) {
+            if (!defaultMessage) {
+                throw path.buildCodeFrameError('[React Intl] Message descriptors require an `defaultMessage`.');
+            }
         }
 
         var messages = file.get(MESSAGES);
         if (messages.has(id)) {
             var existing = messages.get(id);
 
-            if (description !== existing.description || defaultMessage !== existing.defaultMessage) {
-
+            if (description !== existing.description || (defaultMessage || id) !== existing.defaultMessage) {
                 throw path.buildCodeFrameError('[React Intl] Duplicate message id: "' + id + '", ' + 'but the `description` and/or `defaultMessage` are different.');
             }
         }
@@ -205,6 +213,333 @@ exports.default = function (_ref) {
         return !!path.node[EXTRACTED];
     }
 
+    var existsCache = {};
+    var contentsCache = {};
+
+    function generateJSONMultiFile(file, opts, descriptors) {
+        var _file$opts = file.opts,
+            filename = _file$opts.filename,
+            basename = _file$opts.basename;
+
+        // Make sure the relative path is "absolute" before
+        // joining it with the `messagesDir`.
+
+        var relativePath = p.join(p.sep, p.relative(process.cwd(), filename));
+
+        var messagesFilename = p.join(opts.messagesDir, p.dirname(relativePath), basename + '.json');
+
+        var messagesFile = (0, _stringify2.default)(descriptors, null, 2);
+
+        (0, _mkdirp.sync)(p.dirname(messagesFilename));
+        (0, _fs.writeFileSync)(messagesFilename, messagesFile);
+    }
+
+    function generateJSONSingleFile(file, opts, descriptors) {
+        var messages = {};
+
+        var _iteratorNormalCompletion = true;
+        var _didIteratorError = false;
+        var _iteratorError = undefined;
+
+        try {
+            for (var _iterator = (0, _getIterator3.default)(descriptors), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                var descriptor = _step.value;
+
+                messages[descriptor.id] = descriptor.defaultMessage;
+            }
+        } catch (err) {
+            _didIteratorError = true;
+            _iteratorError = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion && _iterator.return) {
+                    _iterator.return();
+                }
+            } finally {
+                if (_didIteratorError) {
+                    throw _iteratorError;
+                }
+            }
+        }
+
+        var _iteratorNormalCompletion2 = true;
+        var _didIteratorError2 = false;
+        var _iteratorError2 = undefined;
+
+        try {
+            var _loop = function _loop() {
+                var locale = _step2.value;
+
+                var localeFileName = p.join(opts.messagesDir, locale + '.json');
+
+                var localeMessages = {};
+                var existingContentsHash = null;
+
+                if (existsCache[localeFileName] === undefined) {
+                    existsCache[localeFileName] = (0, _fs.existsSync)(localeFileName);
+                }
+
+                if (existsCache[localeFileName]) {
+                    if (contentsCache[localeFileName] === undefined) {
+                        contentsCache[localeFileName] = {
+                            contents: (0, _fs.readFileSync)(localeFileName)
+                        };
+                        contentsCache[localeFileName].md5 = (0, _crypto.createHash)('md5').update(contentsCache[localeFileName].contents).digest('hex');
+                    }
+
+                    localeMessages = JSON.parse(contentsCache[localeFileName].contents);
+                    existingContentsHash = contentsCache[localeFileName].md5;
+                }
+
+                localeMessages = (0, _assign2.default)({}, messages, localeMessages);
+                localeMessages = (0, _keys2.default)(localeMessages).sort().reduce(function (o, k) {
+                    o[k] = localeMessages[k];
+                    return o;
+                }, {});
+
+                var newContents = (0, _stringify2.default)(localeMessages, null, 2) + '\n';
+                var newContentsHash = (0, _crypto.createHash)('md5').update(newContents).digest('hex');
+
+                if (newContentsHash !== existingContentsHash) {
+                    if (!existsCache[localeFileName]) {
+                        (0, _mkdirp.sync)(opts.messagesDir);
+                    }
+                    (0, _fs.writeFileSync)(localeFileName, newContents);
+                    existsCache[localeFileName] = true;
+                    contentsCache[localeFileName] = {
+                        contents: newContents,
+                        md5: newContentsHash
+                    };
+                }
+            };
+
+            for (var _iterator2 = (0, _getIterator3.default)(opts.locales || []), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                _loop();
+            }
+        } catch (err) {
+            _didIteratorError2 = true;
+            _iteratorError2 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                    _iterator2.return();
+                }
+            } finally {
+                if (_didIteratorError2) {
+                    throw _iteratorError2;
+                }
+            }
+        }
+    }
+
+    function generateXLIFF12(file, opts, descriptors) {
+        var relativeFileName = p.relative(process.cwd(), file.opts.filename);
+
+        var _iteratorNormalCompletion3 = true;
+        var _didIteratorError3 = false;
+        var _iteratorError3 = undefined;
+
+        try {
+            for (var _iterator3 = (0, _getIterator3.default)(opts.locales || []), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                var locale = _step3.value;
+
+                var _localeFileName = p.join(opts.messagesDir, locale + '.xliff');
+
+                if (existsCache[_localeFileName] === undefined) {
+                    existsCache[_localeFileName] = (0, _fs.existsSync)(_localeFileName);
+                }
+
+                var existingDoc = void 0;
+                var _existingContentsHash = null;
+
+                if (existsCache[_localeFileName]) {
+                    if (contentsCache[_localeFileName] === undefined) {
+                        contentsCache[_localeFileName] = {
+                            contents: (0, _fs.readFileSync)(_localeFileName)
+                        };
+                        contentsCache[_localeFileName].md5 = (0, _crypto.createHash)('md5').update(contentsCache[_localeFileName].contents).digest('hex');
+                    }
+
+                    _existingContentsHash = contentsCache[_localeFileName].md5;
+                    existingDoc = (0, _libxmljs.parseXml)(contentsCache[_localeFileName].contents);
+
+                    var versionAttribute = existingDoc.root().attr('version');
+
+                    if (!versionAttribute || versionAttribute.value() !== '1.2') {
+                        throw '[React Intl] File ' + _localeFileName + ' is not XLIFF 1.2 file.';
+                    }
+                } else {
+                    existingDoc = new _libxmljs.Document('1.0', 'utf-8');
+                    var _rootNode = new _libxmljs.Element(existingDoc, 'xliff');
+                    _rootNode.namespace(XLIFF12_NAMESPACE);
+                    _rootNode.attr({
+                        'version': '1.2'
+                    });
+                    existingDoc.root(_rootNode);
+                }
+
+                var newDoc = new _libxmljs.Document('1.0', 'utf-8');
+                var rootNode = new _libxmljs.Element(newDoc, 'xliff');
+                rootNode.namespace(XLIFF12_NAMESPACE);
+                rootNode.attr({
+                    'version': '1.2'
+                });
+                newDoc.root(rootNode);
+
+                var appendFileNodes = [];
+                var _iteratorNormalCompletion4 = true;
+                var _didIteratorError4 = false;
+                var _iteratorError4 = undefined;
+
+                try {
+                    for (var _iterator4 = (0, _getIterator3.default)(existingDoc.find('//xliff:file', { xliff: XLIFF12_NAMESPACE })), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                        var existingFileNode = _step4.value;
+
+                        var original = existingFileNode.attr('original').value();
+
+                        if (original < relativeFileName) {
+                            rootNode.addChild(existingFileNode);
+                        } else if (original > relativeFileName) {
+                            appendFileNodes.push(existingFileNode);
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError4 = true;
+                    _iteratorError4 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion4 && _iterator4.return) {
+                            _iterator4.return();
+                        }
+                    } finally {
+                        if (_didIteratorError4) {
+                            throw _iteratorError4;
+                        }
+                    }
+                }
+
+                var fileNode = new _libxmljs.Element(newDoc, 'file');
+                fileNode.attr({
+                    'original': relativeFileName,
+                    'datatype': 'plaintext',
+                    'source-language': 'en',
+                    'target-language': locale
+                });
+                rootNode.addChild(fileNode);
+
+                var bodyNode = new _libxmljs.Element(newDoc, 'body');
+                fileNode.addChild(bodyNode);
+
+                var _iteratorNormalCompletion5 = true;
+                var _didIteratorError5 = false;
+                var _iteratorError5 = undefined;
+
+                try {
+                    for (var _iterator5 = (0, _getIterator3.default)(descriptors), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                        var descriptor = _step5.value;
+
+                        var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
+                        transUnitNode.attr({
+                            id: descriptor.id
+                        });
+                        bodyNode.addChild(transUnitNode);
+
+                        var sourceNode = new _libxmljs.Element(newDoc, 'source');
+                        sourceNode.text(descriptor.id);
+                        transUnitNode.addChild(sourceNode);
+
+                        var targetNode = new _libxmljs.Element(newDoc, 'target');
+
+                        var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']/xliff:body/xliff:trans-unit[xliff:source[text() = \'' + descriptor.id + '\']]/xliff:target', {
+                            xliff: XLIFF12_NAMESPACE
+                        });
+
+                        if (existingTargetNode) {
+                            targetNode.text(existingTargetNode.text().trim());
+                        } else {
+                            targetNode.text(descriptor.defaultMessage);
+                        }
+                        transUnitNode.addChild(targetNode);
+
+                        if (descriptor.description) {
+                            var noteNode = new _libxmljs.Element(newDoc, 'note');
+                            noteNode.text(descriptor.description);
+                            transUnitNode.addChild(noteNode);
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError5 = true;
+                    _iteratorError5 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion5 && _iterator5.return) {
+                            _iterator5.return();
+                        }
+                    } finally {
+                        if (_didIteratorError5) {
+                            throw _iteratorError5;
+                        }
+                    }
+                }
+
+                var _iteratorNormalCompletion6 = true;
+                var _didIteratorError6 = false;
+                var _iteratorError6 = undefined;
+
+                try {
+                    for (var _iterator6 = (0, _getIterator3.default)(appendFileNodes), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+                        var _existingFileNode = _step6.value;
+
+                        rootNode.addChild(_existingFileNode);
+                    }
+                } catch (err) {
+                    _didIteratorError6 = true;
+                    _iteratorError6 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion6 && _iterator6.return) {
+                            _iterator6.return();
+                        }
+                    } finally {
+                        if (_didIteratorError6) {
+                            throw _iteratorError6;
+                        }
+                    }
+                }
+
+                var _newContents = newDoc.toString(true).trim() + '\n';
+                var _newContentsHash = (0, _crypto.createHash)('md5').update(_newContents).digest('hex');
+
+                if (_newContentsHash !== _existingContentsHash) {
+                    if (!existsCache[_localeFileName]) {
+                        (0, _mkdirp.sync)(opts.messagesDir);
+                    }
+                    (0, _fs.writeFileSync)(_localeFileName, _newContents);
+                    existsCache[_localeFileName] = true;
+                    contentsCache[_localeFileName] = {
+                        contents: _newContents,
+                        md5: _newContentsHash
+                    };
+                }
+            }
+        } catch (err) {
+            _didIteratorError3 = true;
+            _iteratorError3 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                    _iterator3.return();
+                }
+            } finally {
+                if (_didIteratorError3) {
+                    throw _iteratorError3;
+                }
+            }
+        }
+    }
+
+    var generators = (_generators = {}, (0, _defineProperty3.default)(_generators, FORMAT_JSON_MULTI_FILE, generateJSONMultiFile), (0, _defineProperty3.default)(_generators, FORMAT_JSON_SINGLE_FILE, generateJSONSingleFile), (0, _defineProperty3.default)(_generators, FORMAT_XLIFF12, generateXLIFF12), _generators);
+
     return {
         pre: function pre(file) {
             if (!file.has(MESSAGES)) {
@@ -213,93 +548,32 @@ exports.default = function (_ref) {
         },
         post: function post(file) {
             var opts = this.opts;
+            var fileName = file.opts.filename;
 
 
             var messages = file.get(MESSAGES);
             var descriptors = [].concat((0, _toConsumableArray3.default)(messages.values()));
+
+            descriptors.sort(function (a, b) {
+                if (a.id < b.id) {
+                    return -1;
+                } else if (a.id > b.id) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            });
+
             file.metadata['react-intl'] = { messages: descriptors };
 
-            if (opts.messagesDir && opts.locales && opts.locales.length > 0 && descriptors.length > 0) {
-                var defaultLocale = opts.locales[0];
+            if (opts.messagesDir && descriptors.length > 0) {
+                var generate = generators[opts.format || FORMAT_JSON_MULTI_FILE];
 
-                (0, _mkdirp.sync)(opts.messagesDir);
-
-                var _messages = {};
-                var _iteratorNormalCompletion = true;
-                var _didIteratorError = false;
-                var _iteratorError = undefined;
-
-                try {
-                    for (var _iterator = (0, _getIterator3.default)(descriptors), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                        var descriptor = _step.value;
-
-                        _messages[descriptor.id] = descriptor.defaultMessage;
-                    }
-                } catch (err) {
-                    _didIteratorError = true;
-                    _iteratorError = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion && _iterator.return) {
-                            _iterator.return();
-                        }
-                    } finally {
-                        if (_didIteratorError) {
-                            throw _iteratorError;
-                        }
-                    }
+                if (!generate) {
+                    throw '[React Intl] Unknown format ' + opts.format + '.';
                 }
 
-                var _iteratorNormalCompletion2 = true;
-                var _didIteratorError2 = false;
-                var _iteratorError2 = undefined;
-
-                try {
-                    var _loop = function _loop() {
-                        var locale = _step2.value;
-
-                        var localeFilename = p.join(opts.messagesDir, locale + ".json");
-
-                        var localeMessages = {};
-
-                        if ((0, _fs.existsSync)(localeFilename)) {
-                            try {
-                                localeMessages = JSON.parse((0, _fs.readFileSync)(localeFilename));
-                            } catch (e) {
-                                localeMessages = {};
-                            }
-                        }
-
-                        if (locale === defaultLocale) {
-                            localeMessages = (0, _assign2.default)({}, localeMessages, _messages);
-                        } else {
-                            localeMessages = (0, _assign2.default)({}, _messages, localeMessages);
-                        }
-                        localeMessages = (0, _keys2.default)(localeMessages).sort().reduce(function (o, k) {
-                            o[k] = localeMessages[k];
-                            return o;
-                        }, {});
-
-                        (0, _fs.writeFileSync)(localeFilename, (0, _stringify2.default)(localeMessages, null, 2) + "\n");
-                    };
-
-                    for (var _iterator2 = (0, _getIterator3.default)(opts.locales), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-                        _loop();
-                    }
-                } catch (err) {
-                    _didIteratorError2 = true;
-                    _iteratorError2 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion2 && _iterator2.return) {
-                            _iterator2.return();
-                        }
-                    } finally {
-                        if (_didIteratorError2) {
-                            throw _iteratorError2;
-                        }
-                    }
-                }
+                generate(file, opts, descriptors);
             }
         },
 
@@ -310,8 +584,8 @@ exports.default = function (_ref) {
                     return;
                 }
 
-                var file = state.file;
-                var opts = state.opts;
+                var file = state.file,
+                    opts = state.opts;
 
                 var moduleSourceName = getModuleSourceName(opts);
                 var name = path.get('name');
@@ -388,7 +662,7 @@ exports.default = function (_ref) {
                     storeMessage(descriptor, messageObj, state);
 
                     // Remove description since it's not used at runtime.
-                    messageObj.replaceWith(t.objectExpression([t.objectProperty(t.stringLiteral('id'), t.stringLiteral(descriptor.id)), t.objectProperty(t.stringLiteral('defaultMessage'), t.stringLiteral(descriptor.defaultMessage))]));
+                    messageObj.replaceWith(t.objectExpression([t.objectProperty(t.stringLiteral('id'), t.stringLiteral(descriptor.id)), t.objectProperty(t.stringLiteral('defaultMessage'), t.stringLiteral(descriptor.defaultMessage || descriptor.id))]));
 
                     // Tag the AST node so we don't try to extract it twice.
                     tagAsExtracted(messageObj);
@@ -408,13 +682,17 @@ exports.default = function (_ref) {
     };
 };
 
-var _path = require('path');
-
-var p = _interopRequireWildcard(_path);
+var _crypto = require('crypto');
 
 var _fs = require('fs');
 
+var _libxmljs = require('libxmljs');
+
 var _mkdirp = require('mkdirp');
+
+var _path = require('path');
+
+var p = _interopRequireWildcard(_path);
 
 var _printIcuMessage = require('./print-icu-message');
 
@@ -438,3 +716,9 @@ var DESCRIPTOR_PROPS = new _set2.default(['id', 'description', 'defaultMessage']
 
 var EXTRACTED = (0, _symbol2.default)('ReactIntlExtracted');
 var MESSAGES = (0, _symbol2.default)('ReactIntlMessages');
+
+var XLIFF12_NAMESPACE = 'urn:oasis:names:tc:xliff:document:1.2';
+
+var FORMAT_JSON_MULTI_FILE = 'json-multi-file';
+var FORMAT_JSON_SINGLE_FILE = 'json-single-file';
+var FORMAT_XLIFF12 = 'xliff-1.2';

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,6 @@ exports.default = function (_ref) {
         var file = state.file,
             opts = state.opts;
 
-
         if (!id) {
             throw path.buildCodeFrameError('[React Intl] Message descriptors require an `id`.');
         }
@@ -185,7 +184,7 @@ exports.default = function (_ref) {
             }
         }
 
-        var loc = void 0;
+        var loc = undefined;
         if (opts.extractSourceLocation) {
             loc = (0, _extends3.default)({
                 file: p.relative(process.cwd(), file.opts.filename)
@@ -243,9 +242,9 @@ exports.default = function (_ref) {
 
         try {
             for (var _iterator = (0, _getIterator3.default)(descriptors), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                var descriptor = _step.value;
+                var _descriptor = _step.value;
 
-                messages[descriptor.id] = descriptor.defaultMessage;
+                messages[_descriptor.id] = _descriptor.defaultMessage;
             }
         } catch (err) {
             _didIteratorError = true;
@@ -332,16 +331,77 @@ exports.default = function (_ref) {
         }
     }
 
-    function generateXLIFF12(file, opts, descriptors) {
-        var relativeFileName = p.relative(process.cwd(), file.opts.filename);
+    function copyAddChildElement(doc, el, parent) {
+        var newEl = new _libxmljs.Element(doc, el.name());
+        parent.addChild(newEl);
+        newEl.namespace(el.namespace());
 
         var _iteratorNormalCompletion3 = true;
         var _didIteratorError3 = false;
         var _iteratorError3 = undefined;
 
         try {
-            for (var _iterator3 = (0, _getIterator3.default)(opts.locales || []), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-                var locale = _step3.value;
+            for (var _iterator3 = (0, _getIterator3.default)(el.attrs()), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                var attr = _step3.value;
+
+                newEl.attr((0, _defineProperty3.default)({}, attr.name(), attr.value()));
+                // FIXME: libxmljs does not handle attribute namespaces
+            }
+        } catch (err) {
+            _didIteratorError3 = true;
+            _iteratorError3 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                    _iterator3.return();
+                }
+            } finally {
+                if (_didIteratorError3) {
+                    throw _iteratorError3;
+                }
+            }
+        }
+
+        var _iteratorNormalCompletion4 = true;
+        var _didIteratorError4 = false;
+        var _iteratorError4 = undefined;
+
+        try {
+            for (var _iterator4 = (0, _getIterator3.default)(el.childNodes()), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                var child = _step4.value;
+
+                if (child.type() === "element") {
+                    copyAddChildElement(doc, child, newEl);
+                } else {
+                    newEl.addChild(child);
+                }
+            }
+        } catch (err) {
+            _didIteratorError4 = true;
+            _iteratorError4 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion4 && _iterator4.return) {
+                    _iterator4.return();
+                }
+            } finally {
+                if (_didIteratorError4) {
+                    throw _iteratorError4;
+                }
+            }
+        }
+    }
+
+    function generateXLIFF12(file, opts, descriptors) {
+        var relativeFileName = p.relative(process.cwd(), file.opts.filename);
+
+        var _iteratorNormalCompletion5 = true;
+        var _didIteratorError5 = false;
+        var _iteratorError5 = undefined;
+
+        try {
+            for (var _iterator5 = (0, _getIterator3.default)(opts.locales || []), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                var locale = _step5.value;
 
                 var _localeFileName = p.join(opts.messagesDir, locale + '.xliff');
 
@@ -349,7 +409,7 @@ exports.default = function (_ref) {
                     existsCache[_localeFileName] = (0, _fs.existsSync)(_localeFileName);
                 }
 
-                var existingDoc = void 0;
+                var existingDoc = undefined;
                 var _existingContentsHash = null;
 
                 if (existsCache[_localeFileName]) {
@@ -371,6 +431,7 @@ exports.default = function (_ref) {
                 } else {
                     existingDoc = new _libxmljs.Document('1.0', 'utf-8');
                     var _rootNode = new _libxmljs.Element(existingDoc, 'xliff');
+                    _rootNode.defineNamespace(XLIFF12_NAMESPACE);
                     _rootNode.namespace(XLIFF12_NAMESPACE);
                     _rootNode.attr({
                         'version': '1.2'
@@ -380,6 +441,7 @@ exports.default = function (_ref) {
 
                 var newDoc = new _libxmljs.Document('1.0', 'utf-8');
                 var rootNode = new _libxmljs.Element(newDoc, 'xliff');
+                rootNode.defineNamespace(XLIFF12_NAMESPACE);
                 rootNode.namespace(XLIFF12_NAMESPACE);
                 rootNode.attr({
                     'version': '1.2'
@@ -387,110 +449,21 @@ exports.default = function (_ref) {
                 newDoc.root(rootNode);
 
                 var appendFileNodes = [];
-                var _iteratorNormalCompletion4 = true;
-                var _didIteratorError4 = false;
-                var _iteratorError4 = undefined;
-
-                try {
-                    for (var _iterator4 = (0, _getIterator3.default)(existingDoc.find('//xliff:file', { xliff: XLIFF12_NAMESPACE })), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-                        var existingFileNode = _step4.value;
-
-                        var original = existingFileNode.attr('original').value();
-
-                        if (original < relativeFileName) {
-                            rootNode.addChild(existingFileNode);
-                        } else if (original > relativeFileName) {
-                            appendFileNodes.push(existingFileNode);
-                        }
-                    }
-                } catch (err) {
-                    _didIteratorError4 = true;
-                    _iteratorError4 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion4 && _iterator4.return) {
-                            _iterator4.return();
-                        }
-                    } finally {
-                        if (_didIteratorError4) {
-                            throw _iteratorError4;
-                        }
-                    }
-                }
-
-                var fileNode = new _libxmljs.Element(newDoc, 'file');
-                fileNode.attr({
-                    'original': relativeFileName,
-                    'datatype': 'plaintext',
-                    'source-language': 'en',
-                    'target-language': locale
-                });
-                rootNode.addChild(fileNode);
-
-                var bodyNode = new _libxmljs.Element(newDoc, 'body');
-                fileNode.addChild(bodyNode);
-
-                var _iteratorNormalCompletion5 = true;
-                var _didIteratorError5 = false;
-                var _iteratorError5 = undefined;
-
-                try {
-                    for (var _iterator5 = (0, _getIterator3.default)(descriptors), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                        var descriptor = _step5.value;
-
-                        var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
-                        transUnitNode.attr({
-                            id: descriptor.id
-                        });
-                        bodyNode.addChild(transUnitNode);
-
-                        var sourceNode = new _libxmljs.Element(newDoc, 'source');
-                        sourceNode.text(descriptor.id);
-                        transUnitNode.addChild(sourceNode);
-
-                        var targetNode = new _libxmljs.Element(newDoc, 'target');
-
-                        var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']/xliff:body/xliff:trans-unit[xliff:source[text() = \'' + descriptor.id + '\']]/xliff:target', {
-                            xliff: XLIFF12_NAMESPACE
-                        });
-
-                        if (existingTargetNode) {
-                            targetNode.text(existingTargetNode.text().trim());
-                        } else {
-                            targetNode.text(descriptor.defaultMessage);
-                        }
-                        transUnitNode.addChild(targetNode);
-
-                        if (descriptor.description) {
-                            var noteNode = new _libxmljs.Element(newDoc, 'note');
-                            noteNode.text(descriptor.description);
-                            transUnitNode.addChild(noteNode);
-                        }
-                    }
-                } catch (err) {
-                    _didIteratorError5 = true;
-                    _iteratorError5 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion5 && _iterator5.return) {
-                            _iterator5.return();
-                        }
-                    } finally {
-                        if (_didIteratorError5) {
-                            throw _iteratorError5;
-                        }
-                    }
-                }
-
                 var _iteratorNormalCompletion6 = true;
                 var _didIteratorError6 = false;
                 var _iteratorError6 = undefined;
 
                 try {
-                    for (var _iterator6 = (0, _getIterator3.default)(appendFileNodes), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
-                        var _existingFileNode = _step6.value;
+                    for (var _iterator6 = (0, _getIterator3.default)(existingDoc.find('//xliff:file', { xliff: XLIFF12_NAMESPACE })), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+                        var existingFileNode = _step6.value;
 
-                        rootNode.addChild(_existingFileNode);
+                        var original = existingFileNode.attr('original').value();
+
+                        if (original < relativeFileName) {
+                            copyAddChildElement(newDoc, existingFileNode, rootNode);
+                        } else if (original > relativeFileName) {
+                            appendFileNodes.push(existingFileNode);
+                        }
                     }
                 } catch (err) {
                     _didIteratorError6 = true;
@@ -503,6 +476,101 @@ exports.default = function (_ref) {
                     } finally {
                         if (_didIteratorError6) {
                             throw _iteratorError6;
+                        }
+                    }
+                }
+
+                var fileNode = new _libxmljs.Element(newDoc, 'file');
+                rootNode.addChild(fileNode);
+                fileNode.namespace(XLIFF12_NAMESPACE);
+                fileNode.attr({
+                    'original': relativeFileName,
+                    'datatype': 'plaintext',
+                    'source-language': 'en',
+                    'target-language': locale
+                });
+
+                var bodyNode = new _libxmljs.Element(newDoc, 'body');
+                fileNode.addChild(bodyNode);
+                bodyNode.namespace(XLIFF12_NAMESPACE);
+
+                var _iteratorNormalCompletion7 = true;
+                var _didIteratorError7 = false;
+                var _iteratorError7 = undefined;
+
+                try {
+                    for (var _iterator7 = (0, _getIterator3.default)(descriptors), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
+                        var _descriptor2 = _step7.value;
+
+                        var transUnitNode = new _libxmljs.Element(newDoc, 'trans-unit');
+                        bodyNode.addChild(transUnitNode);
+                        transUnitNode.namespace(XLIFF12_NAMESPACE);
+                        transUnitNode.attr({
+                            id: _descriptor2.id
+                        });
+
+                        var sourceNode = new _libxmljs.Element(newDoc, 'source');
+                        transUnitNode.addChild(sourceNode);
+                        sourceNode.namespace(XLIFF12_NAMESPACE);
+                        sourceNode.text(_descriptor2.id);
+
+                        var targetNode = new _libxmljs.Element(newDoc, 'target');
+                        transUnitNode.addChild(targetNode);
+                        targetNode.namespace(XLIFF12_NAMESPACE);
+
+                        var existingTargetNode = existingDoc.get('//xliff:file[@original = \'' + relativeFileName + '\']/xliff:body/xliff:trans-unit[xliff:source[text() = \'' + _descriptor2.id + '\']]/xliff:target', {
+                            xliff: XLIFF12_NAMESPACE
+                        });
+
+                        if (existingTargetNode) {
+                            targetNode.text(existingTargetNode.text().trim());
+                        } else {
+                            targetNode.text(_descriptor2.defaultMessage);
+                        }
+
+                        if (_descriptor2.description) {
+                            var noteNode = new _libxmljs.Element(newDoc, 'note');
+                            transUnitNode.addChild(noteNode);
+                            noteNode.namespace(XLIFF12_NAMESPACE);
+                            noteNode.text(_descriptor2.description);
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError7 = true;
+                    _iteratorError7 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion7 && _iterator7.return) {
+                            _iterator7.return();
+                        }
+                    } finally {
+                        if (_didIteratorError7) {
+                            throw _iteratorError7;
+                        }
+                    }
+                }
+
+                var _iteratorNormalCompletion8 = true;
+                var _didIteratorError8 = false;
+                var _iteratorError8 = undefined;
+
+                try {
+                    for (var _iterator8 = (0, _getIterator3.default)(appendFileNodes), _step8; !(_iteratorNormalCompletion8 = (_step8 = _iterator8.next()).done); _iteratorNormalCompletion8 = true) {
+                        var _existingFileNode = _step8.value;
+
+                        copyAddChildElement(newDoc, _existingFileNode, rootNode);
+                    }
+                } catch (err) {
+                    _didIteratorError8 = true;
+                    _iteratorError8 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion8 && _iterator8.return) {
+                            _iterator8.return();
+                        }
+                    } finally {
+                        if (_didIteratorError8) {
+                            throw _iteratorError8;
                         }
                     }
                 }
@@ -523,16 +591,16 @@ exports.default = function (_ref) {
                 }
             }
         } catch (err) {
-            _didIteratorError3 = true;
-            _iteratorError3 = err;
+            _didIteratorError5 = true;
+            _iteratorError5 = err;
         } finally {
             try {
-                if (!_iteratorNormalCompletion3 && _iterator3.return) {
-                    _iterator3.return();
+                if (!_iteratorNormalCompletion5 && _iterator5.return) {
+                    _iterator5.return();
                 }
             } finally {
-                if (_didIteratorError3) {
-                    throw _iteratorError3;
+                if (_didIteratorError5) {
+                    throw _iteratorError5;
                 }
             }
         }
@@ -549,7 +617,6 @@ exports.default = function (_ref) {
         post: function post(file) {
             var opts = this.opts;
             var fileName = file.opts.filename;
-
 
             var messages = file.get(MESSAGES);
             var descriptors = [].concat((0, _toConsumableArray3.default)(messages.values()));
@@ -577,7 +644,6 @@ exports.default = function (_ref) {
             }
         },
 
-
         visitor: {
             JSXOpeningElement: function JSXOpeningElement(path, state) {
                 if (wasExtracted(path)) {
@@ -601,7 +667,7 @@ exports.default = function (_ref) {
                         return attr.isJSXAttribute();
                     });
 
-                    var descriptor = createMessageDescriptor(attributes.map(function (attr) {
+                    var _descriptor3 = createMessageDescriptor(attributes.map(function (attr) {
                         return [attr.get('name'), attr.get('value')];
                     }));
 
@@ -611,14 +677,14 @@ exports.default = function (_ref) {
                     // write `<FormattedMessage {...descriptor} />`, because
                     // it will be skipped here and extracted elsewhere.
                     // The descriptor will be extracted only if a `id` prop exists.
-                    if (descriptor.id) {
+                    if (_descriptor3.id) {
                         // Evaluate the Message Descriptor values in a JSX
                         // context, then store it.
-                        descriptor = evaluateMessageDescriptor(descriptor, {
+                        _descriptor3 = evaluateMessageDescriptor(_descriptor3, {
                             isJSXSource: true
                         });
 
-                        storeMessage(descriptor, path, state);
+                        storeMessage(_descriptor3, path, state);
 
                         // Remove description since it's not used at runtime.
                         attributes.some(function (attr) {

--- a/lib/print-icu-message.js
+++ b/lib/print-icu-message.js
@@ -1,0 +1,97 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+exports.default = function (message) {
+    var ast = (0, _intlMessageformatParser.parse)(message);
+    return printICUMessage(ast);
+};
+
+var _intlMessageformatParser = require('intl-messageformat-parser');
+
+var ESCAPED_CHARS = {
+    '\\': '\\\\',
+    '\\#': '\\#',
+    '{': '\\{',
+    '}': '\\}'
+}; /*
+    * Copyright 2015, Yahoo Inc.
+    * Copyrights licensed under the New BSD License.
+    * See the accompanying LICENSE file for terms.
+    */
+
+var ESAPE_CHARS_REGEXP = /\\#|[{}\\]/g;
+
+function printICUMessage(ast) {
+    var printedNodes = ast.elements.map(function (node) {
+        if (node.type === 'messageTextElement') {
+            return printMessageTextASTNode(node);
+        }
+
+        if (!node.format) {
+            return '{' + node.id + '}';
+        }
+
+        switch (getArgumentType(node.format)) {
+            case 'number':
+            case 'date':
+            case 'time':
+                return printSimpleFormatASTNode(node);
+
+            case 'plural':
+            case 'selectordinal':
+            case 'select':
+                return printOptionalFormatASTNode(node);
+        }
+    });
+
+    return printedNodes.join('');
+}
+
+function getArgumentType(format) {
+    var type = format.type;
+    var ordinal = format.ordinal;
+
+    // Special-case ordinal plurals to use `selectordinal` instead of `plural`.
+
+    if (type === 'pluralFormat' && ordinal) {
+        return 'selectordinal';
+    }
+
+    return type.replace(/Format$/, '').toLowerCase();
+}
+
+function printMessageTextASTNode(_ref) {
+    var value = _ref.value;
+
+    return value.replace(ESAPE_CHARS_REGEXP, function (char) {
+        return ESCAPED_CHARS[char];
+    });
+}
+
+function printSimpleFormatASTNode(_ref2) {
+    var id = _ref2.id;
+    var format = _ref2.format;
+
+    var argumentType = getArgumentType(format);
+    var style = format.style ? ', ' + format.style : '';
+
+    return '{' + id + ', ' + argumentType + style + '}';
+}
+
+function printOptionalFormatASTNode(_ref3) {
+    var id = _ref3.id;
+    var format = _ref3.format;
+
+    var argumentType = getArgumentType(format);
+    var offset = format.offset ? ', offset:' + format.offset : '';
+
+    var options = format.options.map(function (option) {
+        var optionValue = printICUMessage(option.value);
+        return ' ' + option.selector + ' {' + optionValue + '}';
+    });
+
+    return '{' + id + ', ' + argumentType + offset + ',' + options.join('') + '}';
+}

--- a/lib/print-icu-message.js
+++ b/lib/print-icu-message.js
@@ -51,8 +51,8 @@ function printICUMessage(ast) {
 }
 
 function getArgumentType(format) {
-    var type = format.type;
-    var ordinal = format.ordinal;
+    var type = format.type,
+        ordinal = format.ordinal;
 
     // Special-case ordinal plurals to use `selectordinal` instead of `plural`.
 
@@ -72,8 +72,8 @@ function printMessageTextASTNode(_ref) {
 }
 
 function printSimpleFormatASTNode(_ref2) {
-    var id = _ref2.id;
-    var format = _ref2.format;
+    var id = _ref2.id,
+        format = _ref2.format;
 
     var argumentType = getArgumentType(format);
     var style = format.style ? ', ' + format.style : '';
@@ -82,8 +82,8 @@ function printSimpleFormatASTNode(_ref2) {
 }
 
 function printOptionalFormatASTNode(_ref3) {
-    var id = _ref3.id;
-    var format = _ref3.format;
+    var id = _ref3.id,
+        format = _ref3.format;
 
     var argumentType = getArgumentType(format);
     var offset = format.offset ? ', offset:' + format.offset : '';

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "babel-runtime": "^6.2.0",
     "intl-messageformat-parser": "^1.2.0",
+    "libxmljs": "~0.18.7",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -145,10 +145,12 @@ export default function ({types: t}) {
             const existing = messages.get(id);
 
             if (description !== existing.description ||
-                (defaultMessage || id) !== existing.defaultMessage) {
+                defaultMessage !== existing.defaultMessage) {
                 throw path.buildCodeFrameError(
                     `[React Intl] Duplicate message id: "${id}", ` +
-                    'but the `description` and/or `defaultMessage` are different.'
+                    'but the `description` and/or `defaultMessage` are different: ' +
+                    `existing description [${existing.description}], new description [${description}], ` +
+                    `existing default message [${existing.defaultMessage}], new default message [${defaultMessage}].`
                 );
             }
         }
@@ -172,7 +174,7 @@ export default function ({types: t}) {
             };
         }
 
-        messages.set(id, {id, description, defaultMessage: defaultMessage || id, ...loc});
+        messages.set(id, {id, description, defaultMessage: defaultMessage, ...loc});
     }
 
     function referencesImport(path, mod, importedNames) {
@@ -225,7 +227,7 @@ export default function ({types: t}) {
         let messages = {};
 
         for (let descriptor of descriptors) {
-            messages[descriptor.id] = descriptor.defaultMessage;
+            messages[descriptor.id] = descriptor.defaultMessage || descriptor.id;
         }
 
         const localeFileName = opts.messagesFile;
@@ -405,7 +407,7 @@ export default function ({types: t}) {
             if (existingTargetNode) {
                 targetNode.text(existingTargetNode.text().trim());
             } else {
-                targetNode.text(descriptor.defaultMessage);
+                targetNode.text(descriptor.defaultMessage || descriptor.id);
             }
 
             if (descriptor.description) {

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ export default function ({types: t}) {
         }
 
         for (let child of el.childNodes()) {
-            if (child.type() === "element") {
+            if (child.type() === 'element') {
                 copyAddChildElement(doc, child, newEl);
             } else {
                 newEl.addChild(child);
@@ -350,7 +350,7 @@ export default function ({types: t}) {
         newDoc.root(rootNode);
 
         let appendFileNodes = [];
-        for (let existingFileNode of existingDoc.find(`//xliff:file`, {xliff: XLIFF12_NAMESPACE})) {
+        for (let existingFileNode of existingDoc.find('//xliff:file', {xliff: XLIFF12_NAMESPACE})) {
             const original = existingFileNode.attr('original').value();
 
             if (original < relativeFileName) {
@@ -451,19 +451,18 @@ export default function ({types: t}) {
 
         post(file) {
             const {opts} = this;
-            const {filename: fileName} = file.opts;
 
             const messages = file.get(MESSAGES);
             const descriptors = [...messages.values()];
 
-            descriptors.sort(function (a, b) {
+            descriptors.sort((a, b) => {
                 if (a.id < b.id) {
                     return -1;
                 } else if (a.id > b.id) {
                     return 1;
-                } else {
-                    return 0;
                 }
+
+                return 0;
             });
 
             file.metadata['react-intl'] = {messages: descriptors};


### PR DESCRIPTION
Extracting messages into one JSON file per component is quite cumbersome to work with. I've added `format` option in which you can specify output format.

- `json-multi-file` = current behavior
- `json-single-file` outputs one JSON file to `messagesFile` in format:
  ```
  {
    "...message ID...": "...default message...",
    ...
  }
  ```
- `xliff-1.2` outputs [XLIFF 1.2](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html) - standardized format for translation that supports messages from multiple source files in single XML file.

I think this would be a great addition to this plugin. What do you think? Thank you for feedback.