### PR TITLE
Add overrideIdFn option to allow manipulation of IDs during extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Extracts string messages for translation from modules that use [React Intl][].
 
 ### React Intl
 This Babel plugin works with React Intl v2.x
-  
+
 ### Babel
 - **3.x** of this plugin works with Babel 7
 - **2.x** works with Babel 6
@@ -48,6 +48,8 @@ If a message descriptor has a `description`, it'll be removed from the source af
 - **`extractSourceLocation`**: Whether the metadata about the location of the message in the source file should be extracted. If `true`, then `file`, `start`, and `end` fields will exist for each extracted message descriptors. Defaults to `false`.
 
 - **`moduleSourceName`**: The ES6 module source name of the React Intl package. Defaults to: `"react-intl"`, but can be changed to another name/path to React Intl.
+
+- **`overrideIdFn`**: A function with the signature `(id: string, defaultMessage: string, description: string|object) => string` which allows you to override the ID both in the extracted javascript and messages.
 
 ### Via Node API
 

--- a/src/index.js
+++ b/src/index.js
@@ -271,7 +271,7 @@ export default function ({types: t}) {
                             if (getMessageDescriptorKey(ketPath) === 'description') {
                                 attr.remove();
                             } else if (opts.overrideIdFn && getMessageDescriptorKey(ketPath) === 'id') {
-                                attr.get('value').replaceWith(t.stringLiteral(descriptor.id))
+                                attr.get('value').replaceWith(t.stringLiteral(descriptor.id));
                             }
                         });
 

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export default function ({types: t}) {
         }, {});
     }
 
-    function evaluateMessageDescriptor({...descriptor}, {isJSXSource = false} = {}) {
+    function evaluateMessageDescriptor({...descriptor}, {isJSXSource = false, overrideIdFn} = {}) {
         Object.keys(descriptor).forEach((key) => {
             const valuePath = descriptor[key];
 
@@ -111,6 +111,10 @@ export default function ({types: t}) {
                 descriptor[key] = getMessageDescriptorValue(valuePath);
             }
         });
+
+        if (overrideIdFn) {
+            descriptor.id = overrideIdFn(descriptor.id, descriptor.defaultMessage, descriptor.description);
+        }
 
         return descriptor;
     }
@@ -256,16 +260,18 @@ export default function ({types: t}) {
                         // context, then store it.
                         descriptor = evaluateMessageDescriptor(descriptor, {
                             isJSXSource: true,
+                            overrideIdFn: opts.overrideIdFn,
                         });
 
                         storeMessage(descriptor, path, state);
 
                         // Remove description since it's not used at runtime.
-                        attributes.some((attr) => {
+                        attributes.forEach((attr) => {
                             const ketPath = attr.get('name');
                             if (getMessageDescriptorKey(ketPath) === 'description') {
                                 attr.remove();
-                                return true;
+                            } else if (opts.overrideIdFn && getMessageDescriptorKey(ketPath) === 'id') {
+                                attr.get('value').replaceWith(t.stringLiteral(descriptor.id))
                             }
                         });
 
@@ -278,6 +284,7 @@ export default function ({types: t}) {
             CallExpression(path, state) {
                 const moduleSourceName = getModuleSourceName(state.opts);
                 const callee = path.get('callee');
+                const {opts} = state;
 
                 function assertObjectExpression(node) {
                     if (!(node && node.isObjectExpression())) {
@@ -307,7 +314,7 @@ export default function ({types: t}) {
                     );
 
                     // Evaluate the Message Descriptor values, then store it.
-                    descriptor = evaluateMessageDescriptor(descriptor);
+                    descriptor = evaluateMessageDescriptor(descriptor, {overrideIdFn: opts.overrideIdFn});
                     storeMessage(descriptor, messageObj, state);
 
                     // Remove description since it's not used at runtime.

--- a/test/fixtures/overrideIdFn/actual.js
+++ b/test/fixtures/overrideIdFn/actual.js
@@ -1,0 +1,42 @@
+import React, {Component} from 'react';
+import {defineMessages, FormattedMessage, FormattedHTMLMessage} from 'react-intl';
+
+const msgs = defineMessages({
+    header: {
+        id: 'foo.bar.baz',
+        defaultMessage: 'Hello World!',
+        description: 'The default message',
+    },
+    content: {
+        id: 'foo.bar.biff',
+        defaultMessage: 'Hello Nurse!',
+        description: {
+            text: 'Something for the translator.',
+            metadata: 'Additional metadata content.',
+        },
+    },
+});
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <div>
+                <h1><FormattedMessage {...msgs.header}/></h1>
+                <p><FormattedMessage {...msgs.content}/></p>
+                <FormattedMessage
+                    id='foo.bar.zoo'
+                    defaultMessage='Hello World!'
+                    description={{
+                        text: 'Something for the translator. Another description',
+                        metadata: 'Additional metadata content.',
+                    }}
+                />
+                <FormattedHTMLMessage
+                    id='foo.bar.delta'
+                    defaultMessage='<h1>Hello World!</h1>'
+                    description='The default message.'
+                />
+            </div>
+        );
+    }
+}

--- a/test/fixtures/overrideIdFn/expected.js
+++ b/test/fixtures/overrideIdFn/expected.js
@@ -1,0 +1,70 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireWildcard(require("react"));
+
+var _reactIntl = require("react-intl");
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var msgs = (0, _reactIntl.defineMessages)({
+  header: {
+    "id": "HELLO.foo.bar.baz.12.string",
+    "defaultMessage": "Hello World!"
+  },
+  content: {
+    "id": "HELLO.foo.bar.biff.12.object",
+    "defaultMessage": "Hello Nurse!"
+  }
+});
+
+var Foo =
+/*#__PURE__*/
+function (_Component) {
+  _inherits(Foo, _Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: "render",
+    value: function render() {
+      return _react.default.createElement("div", null, _react.default.createElement("h1", null, _react.default.createElement(_reactIntl.FormattedMessage, msgs.header)), _react.default.createElement("p", null, _react.default.createElement(_reactIntl.FormattedMessage, msgs.content)), _react.default.createElement(_reactIntl.FormattedMessage, {
+        id: "HELLO.foo.bar.zoo.12.object",
+        defaultMessage: "Hello World!"
+      }), _react.default.createElement(_reactIntl.FormattedHTMLMessage, {
+        id: "HELLO.foo.bar.delta.21.string",
+        defaultMessage: "<h1>Hello World!</h1>"
+      }));
+    }
+  }]);
+
+  return Foo;
+}(_react.Component);
+
+exports.default = Foo;

--- a/test/fixtures/overrideIdFn/expected.json
+++ b/test/fixtures/overrideIdFn/expected.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "HELLO.foo.bar.baz.12.string",
+    "description": "The default message",
+    "defaultMessage": "Hello World!"
+  },
+  {
+    "id": "HELLO.foo.bar.biff.12.object",
+    "description": {
+      "text": "Something for the translator.",
+      "metadata": "Additional metadata content."
+    },
+    "defaultMessage": "Hello Nurse!"
+  },
+  {
+    "id": "HELLO.foo.bar.zoo.12.object",
+    "description": {
+      "text": "Something for the translator. Another description",
+      "metadata": "Additional metadata content."
+    },
+    "defaultMessage": "Hello World!"
+  },
+  {
+    "id": "HELLO.foo.bar.delta.21.string",
+    "description": "The default message.",
+    "defaultMessage": "<h1>Hello World!</h1>"
+  }
+]

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ const skipTests = [
     'moduleSourceName',
     'icuSyntax',
     'removeDescriptions',
+    'overrideIdFn',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -60,6 +61,25 @@ describe('options', () => {
             assert(e);
             assert(/Message must have a `description`/.test(e.message));
         }
+    });
+
+    it('correctly overrides the id when overrideIdFn is provided', () => {
+        const fixtureDir = path.join(fixturesDir, 'overrideIdFn');
+
+        const actual = transform(path.join(fixtureDir, 'actual.js'), {
+            overrideIdFn: (id, defaultMessage, description) => {
+                return `HELLO.${id}.${defaultMessage.length}.${typeof description}`;
+            },
+        });
+
+        // Check code output
+        const expected = fs.readFileSync(path.join(fixtureDir, 'expected.js'));
+        assert.equal(trim(actual), trim(expected));
+
+        // Check message output
+        const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
+        assert.equal(trim(actualMessages), trim(expectedMessages));
     });
 
     it('allows no description when enforceDescription=false', () => {


### PR DESCRIPTION
Adds the possibility to override message IDs during extraction both for `.json` and `.js` output by providing an override function with the signature `(id: string, defaultMessage:string, description: string|object) => string`

Example:

```
transform(path.join(fixtureDir, 'actual.js'), {
    overrideIdFn: (id, defaultMessage, description) => {
        return `HELLO.${id}.${defaultMessage.length}.${typeof description}`;
    },
});
```